### PR TITLE
Feature/13 label UI

### DIFF
--- a/src/components/Atoms/Input/index.tsx
+++ b/src/components/Atoms/Input/index.tsx
@@ -36,9 +36,9 @@ const Input = ({ disabled = false, inputMaxLength = defaultMaxLength, ...props }
   useEffect(() => {}, [inputValue]);
 
   const handleOnClickForm = () => {
-    if (disabled) return;
+    if (!onClick || disabled) return;
     inputRef?.current?.focus();
-    onClick!();
+    onClick();
   };
 
   const handleOnChangeInput = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Atoms/Label/Label.stories.tsx
+++ b/src/components/Atoms/Label/Label.stories.tsx
@@ -13,13 +13,14 @@ export const Initial = Template.bind({});
 Initial.args = {
   title: '레이블',
   labelStyle: 'LIGHT',
+  textColor: 'BLACK',
 };
 
 export const Light = Template.bind({});
 Light.args = {
-  title: '레이블',
-  labelStyle: 'LIGHT',
+  ...Initial.args,
   backgroundColor: '#F85149',
+  textColor: 'BLACK',
 };
 
 export const Dark = Template.bind({});
@@ -27,12 +28,13 @@ Dark.args = {
   title: '레이블',
   labelStyle: 'DARK',
   backgroundColor: '#F85149',
+  textColor: 'WHITE',
 };
 
-export const withIcon = Template.bind({
+export const WithIcon = Template.bind({
   backgrounds: 'black',
 });
-withIcon.args = {
+WithIcon.args = {
   ...Initial.args,
   icon: <Icon icon="Smile" stroke="#fff" />,
 };

--- a/src/components/Atoms/Label/index.styles.ts
+++ b/src/components/Atoms/Label/index.styles.ts
@@ -2,7 +2,7 @@ import { LabelTypes } from '@/components/Atoms/Label';
 import styled, { css } from 'styled-components';
 import { darken, lighten } from 'polished';
 
-type StyledLabelTypes = Pick<LabelTypes, 'labelStyle' | 'backgroundColor'>;
+type StyledLabelTypes = Pick<LabelTypes, 'labelStyle' | 'backgroundColor' | 'textColor'>;
 
 export const Label = styled.div<StyledLabelTypes>`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
@@ -11,7 +11,7 @@ export const Label = styled.div<StyledLabelTypes>`
   padding: 4px 16px;
   border-radius: 30px;
 
-  ${({ labelStyle, backgroundColor }) => {
+  ${({ labelStyle, backgroundColor, textColor }) => {
     if (labelStyle === 'DARK') {
       return css`
         background: ${darken(0.5, backgroundColor)};
@@ -23,7 +23,7 @@ export const Label = styled.div<StyledLabelTypes>`
     if (labelStyle === 'LIGHT') {
       return css`
         background: ${backgroundColor};
-        color: ${backgroundColor === '#ffffff' ? '#000' : '#FFF'};
+        color: ${textColor === 'WHITE' ? '#FFF' : '#000'};
       `;
     }
   }}

--- a/src/components/Atoms/Label/index.tsx
+++ b/src/components/Atoms/Label/index.tsx
@@ -7,15 +7,16 @@ export interface LabelTypes {
   icon?: React.ReactNode;
   labelStyle?: 'LIGHT' | 'DARK';
   backgroundColor: string;
+  textColor: 'WHITE' | 'BLACK';
 }
 
 const DEFAULT_COLORS = COLORS.PRIMARY.BLUE;
 
 const Label = ({ labelStyle = 'LIGHT', backgroundColor = DEFAULT_COLORS, ...props }: LabelTypes) => {
-  const { title, icon } = props;
+  const { title, icon, textColor } = props;
 
   return (
-    <S.Label labelStyle={labelStyle} backgroundColor={backgroundColor}>
+    <S.Label labelStyle={labelStyle} backgroundColor={backgroundColor} textColor={textColor}>
       {icon}
       <span>{title}</span>
     </S.Label>

--- a/src/components/Atoms/Radio/index.stories.tsx
+++ b/src/components/Atoms/Radio/index.stories.tsx
@@ -1,0 +1,23 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import Radio from '@/components/Atoms/Radio/';
+
+export default {
+  title: 'Atoms/Radio',
+  component: Radio,
+} as ComponentMeta<typeof Radio>;
+
+const Template: ComponentStory<typeof Radio> = (args) => <Radio {...args} />;
+
+const radioData = {
+  title: 'radioTest',
+  option: [
+    { id: 1, title: 'option1', isChecked: true },
+    { id: 2, title: 'option2' },
+    { id: 3, title: 'option3' },
+  ],
+};
+
+export const Initial = Template.bind({});
+Initial.args = {
+  radioData,
+};

--- a/src/components/Atoms/Radio/index.styled.ts
+++ b/src/components/Atoms/Radio/index.styled.ts
@@ -1,0 +1,35 @@
+import checkOffCircle from '@/assets/icons/checkOffCircle.svg?inline';
+import checkOnCircle from '@/assets/icons/checkOnCircle.svg?inline';
+import styled from 'styled-components';
+
+export const RadioList = styled.div<{ totalNum: number }>`
+  display: grid;
+  grid-template-columns: repeat(${({ totalNum }) => totalNum}, 100px);
+`;
+
+export const Radio = styled.div`
+  input {
+    display: none;
+
+    &:checked ~ label::after {
+      width: 16px;
+      height: 16px;
+      content: url(${checkOnCircle});
+    }
+  }
+
+  label {
+    ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-end' })};
+    flex-direction: row-reverse;
+    cursor: pointer;
+    color: ${({ theme }) => theme.COLORS.BODY};
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL}
+
+    &:after {
+      width: 16px;
+      height: 16px;
+      margin: -6px 10px 0 0;
+      content: url(${checkOffCircle});
+    }
+  }
+`;

--- a/src/components/Atoms/Radio/index.tsx
+++ b/src/components/Atoms/Radio/index.tsx
@@ -1,0 +1,32 @@
+import * as S from '@/components/Atoms/Radio/index.styled';
+
+interface OptionTypes {
+  id: number;
+  title: string;
+  isChecked?: boolean;
+}
+
+interface RadioDataTypes {
+  title: string;
+  option: OptionTypes[];
+}
+
+export interface RadioTypes {
+  radioData: RadioDataTypes;
+}
+
+const Radio = ({ radioData }: RadioTypes) => {
+  const { title: radioTitle, option } = radioData;
+  return (
+    <S.RadioList totalNum={option.length}>
+      {option.map(({ id, title: optionTitle, isChecked = false }) => (
+        <S.Radio key={id}>
+          <input type="radio" id={`${id}-${optionTitle}`} name={radioTitle} defaultChecked={isChecked} />
+          <label htmlFor={`${id}-${optionTitle}`}>{optionTitle}</label>
+        </S.Radio>
+      ))}
+    </S.RadioList>
+  );
+};
+
+export default Radio;

--- a/src/components/Molecules/AddLabelField/index.stories.tsx
+++ b/src/components/Molecules/AddLabelField/index.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import AddLabelField from '@/components/Molecules/AddLabelField';
+
+export default {
+  title: 'Molecules/AddLabelField',
+  component: AddLabelField,
+} as ComponentMeta<typeof AddLabelField>;
+
+const Template: ComponentStory<typeof AddLabelField> = (args) => <AddLabelField {...args} />;
+
+export const New = Template.bind({});
+New.args = {
+  type: 'NEW',
+};
+
+export const Edit = Template.bind({});
+Edit.args = {
+  type: 'EDIT',
+};

--- a/src/components/Molecules/AddLabelField/index.styled.ts
+++ b/src/components/Molecules/AddLabelField/index.styled.ts
@@ -1,0 +1,111 @@
+import styled from 'styled-components';
+
+export const AddLabelField = styled.div`
+  width: 1280px;
+  height: 345px;
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+  border-radius: 16px;
+  padding: 32px;
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(6, 1fr);
+`;
+
+export const Title = styled.h1`
+  ${({ theme }) => theme.FONTSTYLES.TEXT_LARGE}
+  margin-bottom:24px;
+  grid-column: 1/7;
+`;
+
+export const EditField = styled.div`
+  grid-column: 1/7;
+  grid-row: 2/3;
+  display: grid;
+  grid-template-columns: 344px auto;
+  align-items: center;
+
+  & > div:first-child {
+    justify-self: center;
+  }
+`;
+
+export const TextColor = styled.div`
+  label {
+    width: 100px;
+  }
+`;
+
+export const BackgroundColor = styled.div`
+  input {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+    color: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+    width: 80px;
+    border: none;
+    background: transparent;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  svg {
+    cursor: pointer;
+  }
+`;
+
+export const EditForm = styled.div`
+  display: grid;
+  grid-gap: 16px;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: 240px 352px auto;
+  grid-auto-columns: 940px;
+
+  form {
+    &:first-child,
+    &:nth-child(2) {
+      width: 904px;
+      width: inherit;
+      grid-column: 1/4;
+    }
+    &:nth-child(3) {
+      grid-row: 3/4;
+      grid-column: 1/2;
+      width: 240px;
+    }
+    &:nth-child(4) {
+      grid-row: 3/4;
+      grid-column: 2/3;
+      width: 352px;
+    }
+
+    label {
+      ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL}
+      color: ${({ theme }) => theme.COLORS.LABEL}
+    }
+  }
+
+  ${TextColor}, ${BackgroundColor} {
+    ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
+    padding: 0px 24px;
+    border: none;
+    border-radius: 16px;
+    background: ${({ theme }) => theme.COLORS.INPUT_BACKGROUND};
+
+    &>label: first-child {
+      width: 80px;
+      ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL}
+      color: ${({ theme }) => theme.COLORS.LABEL}
+    }
+  }
+`;
+
+export const EditButton = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
+  grid-column: 6/6;
+  grid-row: 3/3;
+
+  button + button {
+    margin-left: 8px;
+  }
+`;

--- a/src/components/Molecules/AddLabelField/index.tsx
+++ b/src/components/Molecules/AddLabelField/index.tsx
@@ -1,0 +1,96 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import Button from '@/components/Atoms/Button';
+import Icon from '@/components/Atoms/Icon';
+import Input from '@/components/Atoms/Input';
+import Label from '@/components/Atoms/Label';
+import Radio from '@/components/Atoms/Radio';
+
+import useInput from '@/hooks/useInput';
+
+import { COLORS } from '@/styles/theme';
+import * as S from '@/components/Molecules/AddLabelField/index.styled';
+
+interface LabelAddFormTypes {
+  type: 'NEW' | 'EDIT';
+}
+
+const [MAX_TITLE_LENTH, MAX_DESCRIPTION_LENGTH, MAX_COLORCODE_LENGTH] = [30, 100, 7];
+
+const AddLabelField = ({ type }: LabelAddFormTypes) => {
+  const title = type === 'NEW' ? '새로운 레이블 추가' : '레이블 편집';
+  const { isTyping: IsTitleTyping, onChangeInput: onChangeTitleInput } = useInput();
+  const { isTyping: IsDescriptionTyping, onChangeInput: onChangeDescriptionInput } = useInput();
+
+  return (
+    <S.AddLabelField>
+      <S.Title>{title}</S.Title>
+      <S.EditField>
+        <Label backgroundColor={COLORS.INPUT_BACKGROUND} textColor="BLACK" title="레이블" />
+        <S.EditForm>
+          <Input
+            inputMaxLength={MAX_TITLE_LENTH}
+            inputPlaceholder="레이블 이름"
+            inputSize="SMALL"
+            inputType="text"
+            onChange={onChangeTitleInput}
+            isTyping={IsTitleTyping}
+          />
+          <Input
+            inputMaxLength={MAX_DESCRIPTION_LENGTH}
+            inputPlaceholder="설명(선택)"
+            inputSize="SMALL"
+            inputType="text"
+            onChange={onChangeDescriptionInput}
+            isTyping={IsDescriptionTyping}
+          />
+          <S.BackgroundColor>
+            <label>배경 색상</label>
+            <input
+              type="text"
+              defaultValue={`${type === 'NEW' ? '#EFF0F6' : 'none'}`}
+              maxLength={MAX_COLORCODE_LENGTH}
+            />
+            <Icon icon="RefreshCcw" stroke="#14142B" />
+          </S.BackgroundColor>
+          <S.TextColor>
+            <label>텍스트 색상</label>
+            <Radio
+              radioData={{
+                title: '텍스트 색상',
+                option: [
+                  { id: 1, title: '어두운 색', isChecked: true },
+                  { id: 2, title: '밝은 색' },
+                ],
+              }}
+            />
+          </S.TextColor>
+        </S.EditForm>
+      </S.EditField>
+      <S.EditButton>
+        {type === 'EDIT' && (
+          <Button
+            buttonStyle="SECONDARY"
+            iconInfo={{
+              icon: 'XSquare',
+              stroke: COLORS.LABEL,
+            }}
+            label="취소"
+            size="SMALL"
+          />
+        )}
+        <Button
+          buttonStyle="STANDARD"
+          iconInfo={{
+            icon: `${type === 'EDIT' ? 'Edit' : 'Plus'}`,
+            fill: `${type === 'EDIT' ? 'none' : '#FEFEFE'}`,
+            stroke: '#FEFEFE',
+          }}
+          label="완료"
+          size="SMALL"
+        />
+      </S.EditButton>
+    </S.AddLabelField>
+  );
+};
+
+export default AddLabelField;

--- a/src/components/Molecules/IssueItem/IssueItem.stories.tsx
+++ b/src/components/Molecules/IssueItem/IssueItem.stories.tsx
@@ -16,7 +16,7 @@ Initial.args = {
   issueInfo: {
     id: 1,
     title: '이슈 제목',
-    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS }],
+    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS, textColor: 'BLACK' }],
     writer: {
       id: 1,
       nickname: 'dotori',

--- a/src/components/Molecules/IssueItem/index.styles.ts
+++ b/src/components/Molecules/IssueItem/index.styles.ts
@@ -1,20 +1,5 @@
 import styled from 'styled-components';
 
-export const StyledIssueItem = styled.div`
-  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
-  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
-  height: 100px;
-  padding: 32px 24px;
-
-  .checkbox {
-    margin-top: -35px;
-  }
-`;
-
-export const StyledIssue = styled.div`
-  margin-left: 32px;
-`;
-
 export const IssueTitle = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
   margin-bottom: 8px;

--- a/src/components/Molecules/IssueItem/index.tsx
+++ b/src/components/Molecules/IssueItem/index.tsx
@@ -10,6 +10,7 @@ import * as S from '@/components/Molecules/IssueItem/index.styles';
 
 import { CheckState } from '@/stores/checkBox';
 import calcTimeForToday from '@/utils/calcForTimeToday';
+import TableItem from '@/components/Molecules/Table/TableItem';
 
 export interface IssueInfoTypes {
   id: number;
@@ -30,16 +31,16 @@ const IssueItem = ({ issueInfo }: IssueItemTypes) => {
   const checkState = useRecoilValue(CheckState);
 
   return (
-    <S.StyledIssueItem>
+    <TableItem templateColumns="60px auto 100px">
       <CheckBox id={id} type="child" checked={checkState.child[id]} />
-      <S.StyledIssue>
+      <div>
         <S.IssueTitle>
           <Icon fill="#C7EBFF" icon="AlertCircle" stroke="#007AFF" />
           <Link className="title" to={`/issues/${id}`}>
             {title}
           </Link>
-          {labels.map(({ backgroundColor, title: labelTitle }) => (
-            <Label key={labelTitle} backgroundColor={backgroundColor} title={labelTitle} />
+          {labels.map(({ title: labelTitle, backgroundColor, textColor }) => (
+            <Label key={labelTitle} backgroundColor={backgroundColor} textColor={textColor} title={labelTitle} />
           ))}
         </S.IssueTitle>
         <S.IssueContent>
@@ -52,13 +53,13 @@ const IssueItem = ({ issueInfo }: IssueItemTypes) => {
             {milestone}
           </Link>
         </S.IssueContent>
-      </S.StyledIssue>
+      </div>
       <S.Assignee>
         {assignees.map(({ id: assigneeId, nickname, profileImage }) => (
           <UserImage key={assigneeId} id={assigneeId} nickname={nickname} imgSize="SMALL" profileImage={profileImage} />
         ))}
       </S.Assignee>
-    </S.StyledIssueItem>
+    </TableItem>
   );
 };
 

--- a/src/components/Molecules/NavLink/index.styles.ts
+++ b/src/components/Molecules/NavLink/index.styles.ts
@@ -41,7 +41,8 @@ export const StyledNavLink = styled(NavLink)`
   }
 
   &.active {
-    color: black;
+    color: ${({ theme }) => theme.COLORS.BODY};
+    background: ${({ theme }) => theme.COLORS.LINE};
     path {
       stroke: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
     }

--- a/src/components/Molecules/NavLink/option.tsx
+++ b/src/components/Molecules/NavLink/option.tsx
@@ -1,0 +1,27 @@
+import Icon from '@/components/Atoms/Icon';
+
+export const labelMilestone = (labelNum: number, milestoneNum: number) => [
+  {
+    icon: <Icon icon="Tag" stroke="#14142B" />,
+    link: '/label',
+    title: `레이블 (${labelNum})`,
+  },
+  {
+    icon: <Icon fill="#14142B" icon="Milestone" />,
+    link: '/milestone',
+    title: `마일스톤 (${milestoneNum})`,
+  },
+];
+
+export const openCloseIssue = (openIssueNum: number, closeIssueNum: number) => [
+  {
+    icon: <Icon icon="AlertCircle" stroke="#007AFF" />,
+    title: `열린 이슈 (${openIssueNum})`,
+    link: '/issues/open',
+  },
+  {
+    icon: <Icon icon="Archive" stroke="#0025E7" />,
+    title: `닫힌 이슈 (${closeIssueNum})`,
+    link: '/issues/close',
+  },
+];

--- a/src/components/Molecules/Table/TableHeader/index.tsx
+++ b/src/components/Molecules/Table/TableHeader/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export interface TableHeaderTypes {
+  children: React.ReactNode;
+  templateColumns: string;
+}
+
+type HeaderTypes = Pick<TableHeaderTypes, 'templateColumns'>;
+
+export const Header = styled.div<HeaderTypes>`
+  display: grid;
+  align-items: center;
+  grid-template-columns: ${({ templateColumns }) => templateColumns};
+  padding: 18px 32px;
+  border-radius: 10px 10px 0 0;
+  ${({ theme }) => theme.FONTSTYLES.LINK_SMALL};
+  background: ${({ theme }) => theme.COLORS.BACKGROUND};
+
+  a {
+    padding: 0px;
+  }
+  a + a {
+    padding-left: 24px;
+  }
+
+  .checkbox {
+    margin-top: -7px;
+  }
+`;
+
+const TableHeader = ({ children, templateColumns }: TableHeaderTypes) => (
+  <Header templateColumns={templateColumns}>{children}</Header>
+);
+export default TableHeader;

--- a/src/components/Molecules/Table/TableItem/index.tsx
+++ b/src/components/Molecules/Table/TableItem/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface TableItemTypes {
+  templateColumns: string;
+  children: React.ReactNode;
+}
+
+type ItemTypes = Pick<TableItemTypes, 'templateColumns'>;
+
+export const Item = styled.div<ItemTypes>`
+  display: grid;
+  grid-template-columns: ${({ templateColumns }) => templateColumns};
+  align-content: center;
+  align-items: center;
+  height: 100px;
+  padding: 36px 32px;
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+  ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+
+  .checkbox {
+    margin-top: -35px;
+  }
+`;
+
+const TableItem = ({ templateColumns, children }: TableItemTypes) => (
+  <Item templateColumns={templateColumns}>{children}</Item>
+);
+export default TableItem;

--- a/src/components/Molecules/Table/index.stories.tsx
+++ b/src/components/Molecules/Table/index.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Table from '@/components/Molecules/Table';
+import TableItem from './TableItem';
+
+export default {
+  title: 'Molecules/Table',
+  component: Table,
+} as ComponentMeta<typeof Table>;
+
+const Template: ComponentStory<typeof Table> = (args) => <Table {...args} />;
+
+export const Initial = Template.bind({});
+Initial.args = {
+  header: <span>헤더</span>,
+  item: (
+    <>
+      <TableItem templateColumns="240px">
+        <span>내용</span>
+      </TableItem>
+      <TableItem templateColumns="240px auto 240px">
+        <span>제목</span>
+        <span>내용</span>
+        <div style={{ marginLeft: 'auto' }}>날짜</div>
+      </TableItem>
+    </>
+  ),
+};

--- a/src/components/Molecules/Table/index.styled.ts
+++ b/src/components/Molecules/Table/index.styled.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const Table = styled.div`
+  width: 1280px;
+  border-radius: 10px;
+  color: ${({ theme }) => theme.COLORS.LABEL};
+  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+
+  & > div {
+    border-bottom: 1px solid ${({ theme }) => theme.COLORS.LINE};
+
+    &:last-child {
+      border-radius: 0 0 10px 10px;
+      border-bottom: none;
+    }
+  }
+`;

--- a/src/components/Molecules/Table/index.tsx
+++ b/src/components/Molecules/Table/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import TableHeader from '@/components/Molecules/Table/TableHeader';
+import * as S from '@/components/Molecules/Table/index.styled';
+
+interface TableTypes {
+  header: React.ReactNode;
+  headerTemplateColumns: string;
+  item: React.ReactNode;
+}
+
+const DEFAULT_HEADER_COLUMNS = '240px';
+
+const Table = ({ header, headerTemplateColumns = DEFAULT_HEADER_COLUMNS, item }: TableTypes) => (
+  <S.Table>
+    <TableHeader templateColumns={headerTemplateColumns}>{header}</TableHeader>
+    {item}
+  </S.Table>
+);
+export default Table;

--- a/src/components/Molecules/Table/mock.ts
+++ b/src/components/Molecules/Table/mock.ts
@@ -1,0 +1,32 @@
+import { LabelContentsTypes } from '@/pages/Private/LabelList';
+
+export const labelContents: LabelContentsTypes[] = [
+  {
+    id: 1,
+    title: 'Feature',
+    backgroundColorCode: '#d4c5f9',
+    description: '기능 개발용 라벨입니다.',
+    textColor: 'BLACK',
+  },
+  {
+    id: 2,
+    title: 'Docs',
+    backgroundColorCode: '#d4c510',
+    description: '문서 추가용 라벨입니다.',
+    textColor: 'WHITE',
+  },
+  {
+    id: 3,
+    title: 'Bugs',
+    backgroundColorCode: '#d4c505',
+    description: '버그 수정용 라벨입니다.',
+    textColor: 'BLACK',
+  },
+  {
+    id: 4,
+    title: 'Question',
+    backgroundColorCode: '#d4c501',
+    description: '질문용 라벨입니다.',
+    textColor: 'WHITE',
+  },
+];

--- a/src/components/Organisms/IssueTable/index.styles.ts
+++ b/src/components/Organisms/IssueTable/index.styles.ts
@@ -1,36 +1,7 @@
 import styled from 'styled-components';
 
-export const StyledIssueTable = styled.div`
-  width: 100%;
-  z-index: 1;
-  border-radius: 10px;
-  color: ${({ theme }) => theme.COLORS.LABEL};
-  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
-
-  & > div {
-    border-bottom: 1px solid ${({ theme }) => theme.COLORS.LINE};
-
-    &:last-child {
-      border-radius: 0 0 10px 10px;
-      border-bottom: none;
-    }
-
-    &:first-child {
-    }
-  }
-`;
-
-export const IssueHeader = styled.div`
-  width: inherit;
-  padding: 18px 24px;
-  border-radius: 10px 10px 0 0;
-  background: ${({ theme }) => theme.COLORS.BACKGROUND};
-  ${({ theme }) => theme.MIXIN.FLEX({ align: 'baseline', justify: 'flex-start' })};
-  ${({ theme }) => theme.FONTSTYLES.LINK_SMALL};
-`;
-
 export const IssueStates = styled.div`
-  margin-left: 32px;
+  height: inherit;
 `;
 
 export const IssueInfoTabs = styled.div`

--- a/src/components/Organisms/IssueTable/index.tsx
+++ b/src/components/Organisms/IssueTable/index.tsx
@@ -12,52 +12,63 @@ import { CheckState, IssueTableCheckState } from '@/stores/checkBox';
 import * as S from '@/components/Organisms/IssueTable/index.styles';
 import { DropdownTypes } from '@/components/Molecules/Dropdown/types';
 import { OPEN_CLOSE_DROPDOWN_ARGS } from '@/components/Molecules/Dropdown/mocks';
+import Table from '@/components/Molecules/Table';
 
 interface IssueTableTypes {
   issueListData: IssueInfoTypes[];
   filterTabs: DropdownTypes[];
 }
 
-const openCloseIssue = [
+const openCloseIssue = (openIssueNum: number, closeIssueNum: number) => [
   {
     icon: <Icon icon="AlertCircle" stroke="#007AFF" />,
-    title: '열린 이슈',
+    title: `열린 이슈 (${openIssueNum})`,
     link: '/issues/open',
   },
   {
     icon: <Icon icon="Archive" stroke="#0025E7" />,
-    title: '닫힌 이슈',
+    title: `닫힌 이슈 (${closeIssueNum})`,
     link: '/issues/close',
   },
 ];
 
+const HEADER_COLUMNS = '60px 500px auto';
+
 const IssueTable = ({ issueListData, filterTabs }: IssueTableTypes) => {
   const [checkState, setCheckState] = useRecoilState(CheckState);
   const { checkedIssueNum } = useRecoilValue(IssueTableCheckState);
+  const [openIssueNum, closeIssueNum] = [2, 3];
 
   useEffect(() => {
     setCheckState({ ...checkState, child: Array.from({ length: issueListData.length }, () => false) });
   }, []);
 
   return (
-    <S.StyledIssueTable>
-      <S.IssueHeader>
-        <CheckBox id={-1} type="parent" checked={checkState.parent} />
-        <S.IssueStates>
-          {checkedIssueNum ? <span>{`${checkedIssueNum}개 이슈 선택`}</span> : <NavLink navData={openCloseIssue} />}
-        </S.IssueStates>
-        <S.IssueInfoTabs>
-          {checkedIssueNum ? (
-            <Dropdown {...OPEN_CLOSE_DROPDOWN_ARGS} />
-          ) : (
-            filterTabs.map((info) => <Dropdown key={info.panelTitle} {...info} />)
-          )}
-        </S.IssueInfoTabs>
-      </S.IssueHeader>
-      {issueListData.map((props) => (
+    <Table
+      header={
+        <>
+          <CheckBox id={-1} type="parent" checked={checkState.parent} />
+          <S.IssueStates>
+            {checkedIssueNum ? (
+              <span>{`${checkedIssueNum}개 이슈 선택`}</span>
+            ) : (
+              <NavLink navData={openCloseIssue(openIssueNum, closeIssueNum)} />
+            )}
+          </S.IssueStates>
+          <S.IssueInfoTabs>
+            {checkedIssueNum ? (
+              <Dropdown {...OPEN_CLOSE_DROPDOWN_ARGS} />
+            ) : (
+              filterTabs.map((info) => <Dropdown key={info.panelTitle} {...info} />)
+            )}
+          </S.IssueInfoTabs>
+        </>
+      }
+      headerTemplateColumns={HEADER_COLUMNS}
+      item={issueListData.map((props) => (
         <IssueItem key={props.id} issueInfo={props} />
       ))}
-    </S.StyledIssueTable>
+    />
   );
 };
 

--- a/src/components/Organisms/IssueTable/index.tsx
+++ b/src/components/Organisms/IssueTable/index.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import CheckBox from '@/components/Atoms/CheckBox';
-import Icon from '@/components/Atoms/Icon';
 import NavLink from '@/components/Molecules/NavLink';
 import IssueItem, { IssueInfoTypes } from '@/components/Molecules/IssueItem';
 import Dropdown from '@/components/Molecules/Dropdown';
@@ -13,24 +12,12 @@ import * as S from '@/components/Organisms/IssueTable/index.styles';
 import { DropdownTypes } from '@/components/Molecules/Dropdown/types';
 import { OPEN_CLOSE_DROPDOWN_ARGS } from '@/components/Molecules/Dropdown/mocks';
 import Table from '@/components/Molecules/Table';
+import { openCloseIssue } from '@/components/Molecules/NavLink/option';
 
 interface IssueTableTypes {
   issueListData: IssueInfoTypes[];
   filterTabs: DropdownTypes[];
 }
-
-const openCloseIssue = (openIssueNum: number, closeIssueNum: number) => [
-  {
-    icon: <Icon icon="AlertCircle" stroke="#007AFF" />,
-    title: `열린 이슈 (${openIssueNum})`,
-    link: '/issues/open',
-  },
-  {
-    icon: <Icon icon="Archive" stroke="#0025E7" />,
-    title: `닫힌 이슈 (${closeIssueNum})`,
-    link: '/issues/close',
-  },
-];
 
 const HEADER_COLUMNS = '60px 500px auto';
 

--- a/src/components/Organisms/IssueTable/mocks.ts
+++ b/src/components/Organisms/IssueTable/mocks.ts
@@ -1,12 +1,13 @@
+import { IssueInfoTypes } from '@/components/Molecules/IssueItem';
 import { COLORS } from '@/styles/theme';
 
 const DEFAULT_COLORS = COLORS.PRIMARY.BLUE;
 
-export const issueListData = [
+export const issueListData: IssueInfoTypes[] = [
   {
     id: 0,
     title: '이슈 제목',
-    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS }],
+    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS, textColor: 'WHITE' }],
     writer: {
       id: 1,
       nickname: 'dotori',
@@ -40,7 +41,7 @@ export const issueListData = [
   {
     id: 1,
     title: '이슈 제목',
-    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS }],
+    labels: [{ title: 'documentation', backgroundColor: DEFAULT_COLORS, textColor: 'WHITE' }],
     writer: {
       id: 1,
       nickname: 'dotori',

--- a/src/pages/Private/LabelList.tsx
+++ b/src/pages/Private/LabelList.tsx
@@ -1,0 +1,112 @@
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
+import { COLORS } from '@/styles/theme';
+
+import Button from '@/components/Atoms/Button';
+import Label from '@/components/Atoms/Label';
+import Table from '@/components/Molecules/Table';
+import TableItem from '@/components/Molecules/Table/TableItem';
+import NavLink from '@/components/Molecules/NavLink';
+import Header from '@/components/Organisms/Header';
+
+import { LoginUserInfoState } from '@/stores/loginUserInfo';
+
+import { labelMilestone } from '@/components/Molecules/NavLink/option';
+import { labelContents } from '@/components/Molecules/Table/mock';
+
+const SubNav = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+
+  div {
+    overflow: hidden;
+  }
+`;
+
+export const Description = styled.span`
+  width: 800px;
+`;
+
+export const EditButton = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
+
+  button {
+    &:first-child {
+      color: ${({ theme }) => theme.COLORS.LABEL};
+    }
+    &:nth-child(2) {
+      color: ${({ theme }) => theme.COLORS.ERROR.RED};
+    }
+  }
+
+  button + button {
+    margin-left: 24px;
+  }
+`;
+
+export interface LabelContentsTypes {
+  id: number;
+  title: string;
+  backgroundColorCode: string;
+  description: string;
+  textColor: 'WHITE' | 'BLACK';
+}
+
+const [HEADER_COLUMNS, ITEM_COLUMNS] = ['120px', '240px auto 240px'];
+
+const LabelList = () => {
+  const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
+  const [labelNum, milestoneNum] = [labelContents.length, 3];
+
+  return (
+    <div>
+      <Header user={LoginUserInfoStateValue} />
+      <SubNav>
+        <NavLink navData={labelMilestone(labelNum, milestoneNum)} navLinkStyle="LINE" />
+        <Button
+          buttonStyle="STANDARD"
+          iconInfo={{
+            icon: 'Plus',
+            fill: '#FEFEFE',
+            stroke: '#FEFEFE',
+          }}
+          label="추가"
+          size="SMALL"
+        />
+      </SubNav>
+      <Table
+        header={<span>{`${labelNum}개의 레이블`}</span>}
+        headerTemplateColumns={HEADER_COLUMNS}
+        item={labelContents.map(({ id, title, backgroundColorCode, description, textColor }) => (
+          <TableItem key={id} templateColumns={ITEM_COLUMNS}>
+            <Label title={title} backgroundColor={backgroundColorCode} textColor={textColor} />
+            <Description>{description}</Description>
+            <EditButton>
+              <Button
+                buttonStyle="NO_BORDER"
+                iconInfo={{
+                  icon: 'Edit',
+                  stroke: COLORS.LABEL,
+                }}
+                label="편집"
+                size="SMALL"
+              />
+              <Button
+                buttonStyle="NO_BORDER"
+                iconInfo={{
+                  icon: 'Trash',
+                  stroke: COLORS.ERROR.RED,
+                }}
+                label="삭제"
+                size="SMALL"
+              />
+            </EditButton>
+          </TableItem>
+        ))}
+      />
+    </div>
+  );
+};
+
+export default LabelList;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import Home from '@/pages/Home';
 import NotFound from '@/pages/NotFound';
 
+import LabelList from '@/pages/Private/LabelList';
+
 import RedirectAuth from '@/pages/Public/RedirectAuth';
 import Login from '@/pages/Public/Login';
 import OAuthSignUp from '@/pages/Public/SignUp-OAuth';
@@ -8,4 +10,4 @@ import CommonSignUp from '@/pages/Public/SignUp-Common';
 
 import Issues from '@/pages/Private/Issues';
 
-export { Home, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues };
+export { Home, LabelList, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues };

--- a/src/router/PrivateRouter.tsx
+++ b/src/router/PrivateRouter.tsx
@@ -1,11 +1,12 @@
 import { Route, Routes } from 'react-router-dom';
-import { Home, NotFound, Issues } from '@/pages';
+import { Home, NotFound, Issues, LabelList } from '@/pages';
 
 const PrivateRouter = () => (
   <Routes>
     <Route path="/" element={<Home />}>
       <Route index element={<Issues />} />
       <Route path="/issues" element={<Issues />} />
+      <Route path="/label" element={<LabelList />} />
     </Route>
     <Route path="*" element={<NotFound />} />
   </Routes>

--- a/src/utils/debounce.ts
+++ b/src/utils/debounce.ts
@@ -1,7 +1,11 @@
 import React from 'react';
 
 const debounce =
-  (timer: React.MutableRefObject<number>, callback: any, delay: number = 2000) =>
+  (
+    timer: React.MutableRefObject<number>,
+    callback: (event: React.ChangeEvent<HTMLInputElement>) => void,
+    delay: number = 2000,
+  ) =>
   (event: React.ChangeEvent<HTMLInputElement>) => {
     clearTimeout(timer.current);
     // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
## Description

1. 레이블 페이지와 관련한 컴포넌트 구현
- Atoms 
   - Radio 
- Molecules
   - Table 
   - AddLabelField
- Page
   - LabelList
    
2. 리팩토링
Table 컴포넌트로 IssueTable 내부 로직을 대체함 

## Commits

커밋로그 참조 

## 결과

### [ Radio ] 

<img width="365" alt="스크린샷 2022-08-25 오후 4 30 10" src="https://user-images.githubusercontent.com/92701121/186603153-6f101c8c-87ea-416b-b878-277231c6adee.png">

### [ AddLabelField ]

<img width="830" alt="스크린샷 2022-08-25 오후 4 30 49" src="https://user-images.githubusercontent.com/92701121/186603181-7a2c0aa6-c69a-4f0f-8acb-6fa61d4197d1.png">


### [ Label Page ] 
<img width="1423" alt="스크린샷 2022-08-25 오후 4 31 24" src="https://user-images.githubusercontent.com/92701121/186603205-9df0caed-f14f-470c-9a2a-3dffd001ec13.png">
