### PR TITLE
✨ 마일스톤 페이지 UI 및 기능 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
   env: {
     browser: true,
     es2021: true,
+    jest: true,
   },
   extends: [
     'plugin:react/recommended',

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
   stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  staticDirs: ['./public'],
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', '@storybook/addon-interactions'],
   framework: '@storybook/react',
   core: {

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,12 @@
 import { RecoilRoot } from 'recoil';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'styled-components';
+import { initialize, mswDecorator } from 'msw-storybook-addon';
 
 import theme from '../src/styles/theme';
 import GlobalStyle from '../src/styles/globalStyle';
+import { addDecorator } from '@storybook/react';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -15,15 +18,28 @@ export const parameters = {
   },
 };
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
+
 export const decorators = [
   (Story) => (
     <RecoilRoot>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <MemoryRouter>
-          <Story />
-        </MemoryRouter>
-      </ThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle />
+          <MemoryRouter>
+            <Story />
+          </MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
     </RecoilRoot>
   ),
 ];
+
+initialize();
+addDecorator(mswDecorator);

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -27,18 +27,24 @@ const queryClient = new QueryClient({
 });
 
 export const decorators = [
-  (Story) => (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider theme={theme}>
-          <GlobalStyle />
-          <MemoryRouter>
-            <Story />
-          </MemoryRouter>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </RecoilRoot>
-  ),
+  (Story) => {
+    const modalRoot = document.createElement('div');
+    modalRoot.setAttribute('id', 'modal-root');
+    document.body.append(modalRoot);
+
+    return (
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={theme}>
+            <GlobalStyle />
+            <MemoryRouter>
+              <Story />
+            </MemoryRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </RecoilRoot>
+    );
+  },
 ];
 
 initialize();

--- a/.storybook/public/mockServiceWorker.js
+++ b/.storybook/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.44.2).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = 'b3066ef78c2f9090b4ce87e874965995'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the cilent).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@storybook/manager-webpack5": "^6.5.9",
         "@storybook/react": "^6.5.9",
         "@storybook/testing-library": "^0.0.13",
+        "@storybook/testing-react": "^1.3.0",
         "@svgr/webpack": "^6.2.1",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
@@ -70,6 +71,7 @@
         "jest-environment-jsdom": "^28.1.3",
         "jest-transformer-svg": "^2.0.0",
         "msw": "^0.44.2",
+        "msw-storybook-addon": "^1.6.3",
         "prettier": "^2.7.1",
         "style-loader": "^3.3.1",
         "ts-jest": "^28.0.7",
@@ -9899,6 +9901,34 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@storybook/testing-react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-react/-/testing-react-1.3.0.tgz",
+      "integrity": "sha512-TfxzflxwBHSPhetWKuYt239t+1iN8gnnUN8OKo5UGtwwirghKQlApjH23QXW6j8YBqFhmq+yP29Oqf8HgKCFLw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "0.0.2--canary.87bc651.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@storybook/addons": ">=6.4.0",
+        "@storybook/client-api": ">=6.4.0",
+        "@storybook/preview-web": ">=6.4.0",
+        "@storybook/react": ">=6.4.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@storybook/testing-react/node_modules/@storybook/csf": {
+      "version": "0.0.2--canary.87bc651.0",
+      "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
+      "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/@storybook/theming": {
@@ -23595,6 +23625,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/msw-storybook-addon": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.6.3.tgz",
+      "integrity": "sha512-Ps80WdRmXsmenoTwfrgKMNpQD8INUUFyUFyZOecx8QjuqSlL++UYrLaGyACXN2goOn+/VS6rb0ZapbjrasPClg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
+      },
+      "peerDependencies": {
+        "msw": ">=0.35.0 <1.0.0"
       }
     },
     "node_modules/msw/node_modules/chalk": {
@@ -38561,6 +38604,26 @@
         }
       }
     },
+    "@storybook/testing-react": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-react/-/testing-react-1.3.0.tgz",
+      "integrity": "sha512-TfxzflxwBHSPhetWKuYt239t+1iN8gnnUN8OKo5UGtwwirghKQlApjH23QXW6j8YBqFhmq+yP29Oqf8HgKCFLw==",
+      "dev": true,
+      "requires": {
+        "@storybook/csf": "0.0.2--canary.87bc651.0"
+      },
+      "dependencies": {
+        "@storybook/csf": {
+          "version": "0.0.2--canary.87bc651.0",
+          "resolved": "https://registry.npmjs.org/@storybook/csf/-/csf-0.0.2--canary.87bc651.0.tgz",
+          "integrity": "sha512-ajk1Uxa+rBpFQHKrCcTmJyQBXZ5slfwHVEaKlkuFaW77it8RgbPJp/ccna3sgoi8oZ7FkkOyvv1Ve4SmwFqRqw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.15"
+          }
+        }
+      }
+    },
     "@storybook/theming": {
       "version": "6.5.9",
       "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-6.5.9.tgz",
@@ -49217,6 +49280,16 @@
           "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
           "dev": true
         }
+      }
+    },
+    "msw-storybook-addon": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/msw-storybook-addon/-/msw-storybook-addon-1.6.3.tgz",
+      "integrity": "sha512-Ps80WdRmXsmenoTwfrgKMNpQD8INUUFyUFyZOecx8QjuqSlL++UYrLaGyACXN2goOn+/VS6rb0ZapbjrasPClg==",
+      "dev": true,
+      "requires": {
+        "@storybook/addons": "^6.0.0",
+        "is-node-process": "^1.0.1"
       }
     },
     "multicast-dns": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "cross-env NODE_ENV=development webpack serve --config webpack/webpack.dev.js --open --progress",
     "start": "cross-env NODE_ENV=development webpack --config webpack/webpack.dev.js --progress",
     "build": "cross-env NODE_ENV=production webpack --config ./webpack/webpack.prod.js --progress",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006 .storybook/public",
     "build-storybook": "build-storybook",
     "test": "jest"
   },
@@ -53,6 +53,7 @@
     "@storybook/manager-webpack5": "^6.5.9",
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
+    "@storybook/testing-react": "^1.3.0",
     "@svgr/webpack": "^6.2.1",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
@@ -84,6 +85,7 @@
     "jest-environment-jsdom": "^28.1.3",
     "jest-transformer-svg": "^2.0.0",
     "msw": "^0.44.2",
+    "msw-storybook-addon": "^1.6.3",
     "prettier": "^2.7.1",
     "style-loader": "^3.3.1",
     "ts-jest": "^28.0.7",
@@ -96,6 +98,6 @@
     "webpack-merge": "^5.8.0"
   },
   "msw": {
-    "workerDirectory": "public"
+    "workerDirectory": ".storybook/public"
   }
 }

--- a/src/api/milestone.ts
+++ b/src/api/milestone.ts
@@ -1,0 +1,12 @@
+import axios, { AxiosError } from 'axios';
+import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
+
+export const getMilestoneData = async () => {
+  try {
+    const { data } = await axios.get<MilestoneListTypes>('api/milestones');
+    return data;
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};

--- a/src/api/milestone.ts
+++ b/src/api/milestone.ts
@@ -1,9 +1,20 @@
 import axios, { AxiosError } from 'axios';
+import { MilestonesFormTypes } from '@/components/Molecules/EditMilestone';
 import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
 
 export const getMilestoneData = async () => {
   try {
     const { data } = await axios.get<MilestoneListTypes>('api/milestones');
+    return data;
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};
+
+export const createNewMilestone = async (milestoneData: MilestonesFormTypes) => {
+  try {
+    const { data } = await axios.post<MilestonesFormTypes>('api/milestones', milestoneData);
     return data;
   } catch (error) {
     const err = error as AxiosError;

--- a/src/api/milestone.ts
+++ b/src/api/milestone.ts
@@ -21,3 +21,13 @@ export const createNewMilestone = async (milestoneData: MilestonesFormTypes) => 
     throw err;
   }
 };
+
+export const patchMilestoneData = async ({ id, milestoneData }: { id: number; milestoneData: MilestonesFormTypes }) => {
+  try {
+    const { data } = await axios.patch<MilestonesFormTypes>(`api/milestones/${id}`, milestoneData);
+    return data;
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};

--- a/src/api/milestone.ts
+++ b/src/api/milestone.ts
@@ -32,4 +32,22 @@ export const patchMilestoneData = async ({ id, milestoneData }: { id: number; mi
   }
 };
 
+export const patchMilestoneState = async (id: number) => {
+  try {
+    const { data } = await axios.patch<MilestonesFormTypes>(`api/milestones/${id}/status`);
+    return data;
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};
+
+export const deleteMilestone = async (id: number) => {
+  try {
     const { data } = await axios.delete<MilestonesFormTypes>(`api/milestones/${id}`);
+    return data;
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};

--- a/src/api/milestone.ts
+++ b/src/api/milestone.ts
@@ -31,3 +31,5 @@ export const patchMilestoneData = async ({ id, milestoneData }: { id: number; mi
     throw err;
   }
 };
+
+    const { data } = await axios.delete<MilestonesFormTypes>(`api/milestones/${id}`);

--- a/src/components/Atoms/Icon/Icon.stories.tsx
+++ b/src/components/Atoms/Icon/Icon.stories.tsx
@@ -45,19 +45,19 @@ Milestone.args = {
 export const Plus = Template.bind({});
 Plus.args = {
   icon: 'Plus',
-  stroke: COLORS.TITLE_ACVITE,
+  stroke: COLORS.TITLE_ACTIVE,
 };
 
 export const RefreshCcw = Template.bind({});
 RefreshCcw.args = {
   icon: 'RefreshCcw',
-  stroke: COLORS.TITLE_ACVITE,
+  stroke: COLORS.TITLE_ACTIVE,
 };
 
 export const Search = Template.bind({});
 Search.args = {
   icon: 'Search',
-  stroke: COLORS.TITLE_ACVITE,
+  stroke: COLORS.TITLE_ACTIVE,
 };
 
 export const Smile = Template.bind({});

--- a/src/components/Atoms/Icon/index.tsx
+++ b/src/components/Atoms/Icon/index.tsx
@@ -9,7 +9,7 @@ interface IconTypes {
   fill?: string;
 }
 
-const DEFAULT_COLOR = COLORS.TITLE_ACVITE;
+const DEFAULT_COLOR = COLORS.TITLE_ACTIVE;
 
 const Icon = ({ icon, stroke = DEFAULT_COLOR, fill = 'none' }: IconTypes) => {
   const SVGIcon = icons[icon];

--- a/src/components/Atoms/Input/index.styles.ts
+++ b/src/components/Atoms/Input/index.styles.ts
@@ -46,7 +46,7 @@ export const Form = styled.form<FormStyleTypes>`
   ${({ isActive }) =>
     isActive &&
     css`
-      color: ${({ theme }) => theme.COLORS.PLACEHOLDER};
+      color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
       background: ${({ theme }) => theme.COLORS.OFF_WHITE};
       border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
     `}

--- a/src/components/Atoms/Input/index.styles.ts
+++ b/src/components/Atoms/Input/index.styles.ts
@@ -63,7 +63,7 @@ export const Form = styled.form<FormStyleTypes>`
   &:focus {
     color: ${({ theme }) => theme.COLORS.PLACEHOLDER};
     background: ${({ theme }) => theme.COLORS.OFF_WHITE};
-    outline: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+    outline: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
   }
 `;
 
@@ -75,7 +75,7 @@ export const Input = styled.input`
 
   ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
 
-  color: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+  color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
 
   &:focus {
     outline: none;

--- a/src/components/Atoms/Input/index.tsx
+++ b/src/components/Atoms/Input/index.tsx
@@ -4,6 +4,7 @@ import * as S from '@/components/Atoms/Input/index.styles';
 
 export interface InputTypes {
   disabled?: boolean;
+  inputLabel?: string;
   inputSize: 'SMALL' | 'MEDIUM' | 'LARGE';
   inputType: string;
   inputValue?: string;
@@ -22,6 +23,7 @@ const Input = ({ disabled = false, inputMaxLength = defaultMaxLength, ...props }
   const {
     isActive = false,
     isTyping = false,
+    inputLabel,
     inputType,
     inputSize,
     inputValue,
@@ -50,7 +52,7 @@ const Input = ({ disabled = false, inputMaxLength = defaultMaxLength, ...props }
 
   return (
     <S.Form isActive={isActive} inputSize={inputSize} onClick={handleOnClickForm}>
-      {isTyping && <label>{inputPlaceholder}</label>}
+      {isTyping && <label>{inputLabel || inputPlaceholder}</label>}
       <S.Input
         type={inputType}
         disabled={disabled}

--- a/src/components/Atoms/Input/index.tsx
+++ b/src/components/Atoms/Input/index.tsx
@@ -35,7 +35,11 @@ const Input = ({ disabled = false, inputMaxLength = defaultMaxLength, ...props }
 
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {}, [inputValue]);
+  useEffect(() => {
+    if (inputRef.current !== null && inputValue !== undefined) {
+      inputRef.current!.value = inputValue;
+    }
+  }, [inputValue]);
 
   const handleOnClickForm = () => {
     if (disabled) return;

--- a/src/components/Atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/Atoms/ProgressBar/ProgressBar.stories.tsx
@@ -1,0 +1,21 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import ProgressBar from '@/components/Atoms/ProgressBar';
+
+export default {
+  title: 'Atoms/ProgressBar',
+  component: ProgressBar,
+} as ComponentMeta<typeof ProgressBar>;
+
+const Template: ComponentStory<typeof ProgressBar> = (args) => <ProgressBar {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  open: 5,
+  close: 5,
+};
+
+export const ShowState = Template.bind({});
+ShowState.args = { open: 3, close: 7, showState: true };
+
+export const ShowTitle = Template.bind({});
+ShowTitle.args = { open: 3, close: 7, title: '이슈 트래커' };

--- a/src/components/Atoms/ProgressBar/index.styles.ts
+++ b/src/components/Atoms/ProgressBar/index.styles.ts
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const PrograssBar = styled.progress`
+  display: block;
+  width: 244px;
+  margin-bottom: 8px;
+  appearance: none;
+
+  &::-webkit-progress-bar {
+    border-radius: 10px;
+    background: ${({ theme }) => theme.COLORS.INPUT_BACKGROUND};
+  }
+
+  &::-webkit-progress-value {
+    border-radius: 10px;
+    background: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+  }
+`;
+
+export const PrograssState = styled.div`
+  display: grid;
+  width: 244px;
+  grid-template-columns: 45% 25% 25%;
+  gap: 8px;
+
+  span {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL};
+  }
+`;
+
+export const PrograssTitle = styled.span`
+  ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+`;

--- a/src/components/Atoms/ProgressBar/index.tsx
+++ b/src/components/Atoms/ProgressBar/index.tsx
@@ -1,0 +1,29 @@
+import * as S from '@/components/Atoms/ProgressBar/index.styles';
+
+export interface PrograssBarTypes {
+  open: number;
+  close: number;
+  showState?: boolean;
+  title?: string;
+}
+
+const PrograssBar = ({ open, close, showState, title }: PrograssBarTypes) => {
+  const percent = 100;
+  const progressValue = Math.floor((close / (open + close)) * 100);
+
+  return (
+    <>
+      <S.PrograssBar value={progressValue} max={percent} />
+      {title && <S.PrograssTitle>{title}</S.PrograssTitle>}
+      {showState && (
+        <S.PrograssState>
+          <span>{progressValue}%</span>
+          <span>열린 이슈 {open}</span>
+          <span>닫힌 이슈 {close}</span>
+        </S.PrograssState>
+      )}
+    </>
+  );
+};
+
+export default PrograssBar;

--- a/src/components/Modal/DeleteMilestone/index.tsx
+++ b/src/components/Modal/DeleteMilestone/index.tsx
@@ -1,0 +1,68 @@
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
+import { ModalState } from '@/components/Modal';
+import Button from '@/components/Atoms/Button';
+import useFetchMilestone from '@/hooks/useFetchMilestone';
+import styled from 'styled-components';
+import { ClickMilestoneState } from '@/stores/milestone';
+
+const StyledDeleteModal = styled.div`
+  h1 {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_LARGE};
+    margin-bottom: 12px;
+  }
+
+  p {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+    margin-bottom: 20px;
+  }
+
+  p + button {
+    margin-bottom: 4px;
+    background: ${({ theme }) => theme.COLORS.PLACEHOLDER};
+
+    &:hover:not([disabled]) {
+      background: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+    }
+  }
+
+  button + button {
+    background: ${({ theme }) => theme.COLORS.ERROR.RED};
+
+    &:hover:not([disabled]) {
+      background: ${({ theme }) => theme.COLORS.ERROR.DARK_RED};
+    }
+  }
+`;
+
+const DeleteMilestoneModal = ({ id }: { id: number }) => {
+  const { deleteMilestoneMutate } = useFetchMilestone();
+  const setIsOpenModalState = useSetRecoilState(ModalState);
+  const resetClickMilestoneState = useResetRecoilState(ClickMilestoneState);
+
+  return (
+    <StyledDeleteModal>
+      <h1>해당 마일스톤을 삭제하겠습니까?</h1>
+      <p>삭제한 마일스톤은 되돌릴 수 없습니다.</p>
+      <Button
+        buttonStyle="STANDARD"
+        label="아니오"
+        size="LARGE"
+        handleOnClick={() => {
+          setIsOpenModalState((state) => !state);
+          resetClickMilestoneState();
+        }}
+      />
+      <Button
+        buttonStyle="STANDARD"
+        label="예"
+        size="LARGE"
+        handleOnClick={() => {
+          deleteMilestoneMutate(id);
+          setIsOpenModalState((state) => !state);
+        }}
+      />
+    </StyledDeleteModal>
+  );
+};
+
+export default DeleteMilestoneModal;

--- a/src/components/Molecules/Dropdown/Panel/index.styles.ts
+++ b/src/components/Molecules/Dropdown/Panel/index.styles.ts
@@ -17,7 +17,7 @@ export const Panel = styled.menu`
     padding: 8px 40px 8px 16px;
     border-radius: 16px;
     background: ${({ theme }) => theme.COLORS.BACKGROUND};
-    color: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+    color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
     ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
   }
 `;
@@ -27,7 +27,7 @@ export const PanelItem = styled.li`
   padding: 8px 16px;
   border-top: 1px solid ${({ theme }) => theme.COLORS.LINE};
   background: ${({ theme }) => theme.COLORS.OFF_WHITE};
-  color: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+  color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
   ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
 
   &:last-child {

--- a/src/components/Molecules/EditMilestone/EditInput/index.styles.ts
+++ b/src/components/Molecules/EditMilestone/EditInput/index.styles.ts
@@ -1,0 +1,27 @@
+import styled, { css } from 'styled-components';
+
+export const EditInput = styled.div<{ isError: boolean }>`
+  ${({ isError }) =>
+    isError &&
+    css`
+      position: relative;
+
+      form {
+        border: 1px solid red;
+        background: ${({ theme }) => theme.COLORS.ERROR.LIGHT_RED};
+
+        label {
+          color: ${({ theme }) => theme.COLORS.ERROR.RED};
+        }
+      }
+
+      &::before {
+        position: absolute;
+        content: 'YYYY-MM-DD 형식으로 입력해주세요.';
+        top: -20px;
+        left: 28px;
+        color: ${({ theme }) => theme.COLORS.ERROR.RED};
+        ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL};
+      }
+    `}
+`;

--- a/src/components/Molecules/EditMilestone/EditInput/index.tsx
+++ b/src/components/Molecules/EditMilestone/EditInput/index.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import * as S from '@/components/Molecules/EditMilestone/EditInput/index.styles';
+import Input from '@/components/Atoms/Input';
+import { MilestonesFormTypes } from '@/components/Molecules/EditMilestone/';
+
+import useInput from '@/hooks/useInput';
+import debounce from '@/utils/debounce';
+
+export interface EditInputTypes {
+  label: string;
+  maxLength: number;
+  placeholder: string;
+  formKey: 'title' | 'description' | 'dueDate';
+  value?: string;
+}
+
+interface EditInputStateTypes {
+  state: MilestonesFormTypes;
+  setState: React.Dispatch<React.SetStateAction<MilestonesFormTypes>>;
+}
+
+const EditInput = ({ ...props }: EditInputTypes & EditInputStateTypes) => {
+  const { label, maxLength, placeholder, formKey, state, setState } = props;
+  const { isActive, isTyping, onChangeInput, onClickInput, onBlurInput } = useInput();
+
+  const timerId = useRef(0);
+  const [isError, setIsError] = useState(false);
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChangeInput(e);
+    if (formKey === 'dueDate') {
+      const reg = /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
+      const checkData = reg.test(e.target.value);
+      setIsError(!checkData);
+      return checkData && setState({ ...state, [formKey]: e.target.value });
+    }
+    setState({ ...state, [formKey]: e.target.value });
+  };
+
+  const handleOnTyping = debounce(timerId, handleOnChange, 300);
+
+  return (
+    <S.EditInput isError={isError}>
+      <Input
+        inputLabel={label}
+        inputMaxLength={maxLength}
+        inputPlaceholder={placeholder}
+        inputSize="SMALL"
+        inputType="text"
+        inputValue={props.value}
+        isActive={isActive}
+        isTyping={isTyping}
+        onBlur={onBlurInput}
+        onChange={handleOnTyping}
+        onClick={onClickInput}
+      />
+    </S.EditInput>
+  );
+};
+
+export default EditInput;

--- a/src/components/Molecules/EditMilestone/EditMilestone.stories.tsx
+++ b/src/components/Molecules/EditMilestone/EditMilestone.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import EditMilestone from '@/components/Molecules/EditMilestone';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
 
 export default {
   title: 'Molecules/EditMilestone',
@@ -13,6 +14,12 @@ ADD.args = {
   editMode: 'ADD',
 };
 
+ADD.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
+  },
+};
+
 export const MODIFY = Template.bind({});
 MODIFY.args = {
   editMode: 'MODIFY',
@@ -20,5 +27,11 @@ MODIFY.args = {
     title: '편집할 마일스톤',
     description: '편집할 마일스톤에 대한 설명',
     dueDate: '2022-08-31',
+  },
+};
+
+MODIFY.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
   },
 };

--- a/src/components/Molecules/EditMilestone/EditMilestone.stories.tsx
+++ b/src/components/Molecules/EditMilestone/EditMilestone.stories.tsx
@@ -1,0 +1,24 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import EditMilestone from '@/components/Molecules/EditMilestone';
+
+export default {
+  title: 'Molecules/EditMilestone',
+  component: EditMilestone,
+} as ComponentMeta<typeof EditMilestone>;
+
+const Template: ComponentStory<typeof EditMilestone> = (args) => <EditMilestone {...args} />;
+
+export const ADD = Template.bind({});
+ADD.args = {
+  editMode: 'ADD',
+};
+
+export const MODIFY = Template.bind({});
+MODIFY.args = {
+  editMode: 'MODIFY',
+  milestoneInfo: {
+    title: '편집할 마일스톤',
+    description: '편집할 마일스톤에 대한 설명',
+    dueDate: '2022-08-31',
+  },
+};

--- a/src/components/Molecules/EditMilestone/constants.ts
+++ b/src/components/Molecules/EditMilestone/constants.ts
@@ -1,0 +1,22 @@
+import { EditInputTypes } from './EditInput';
+
+export const EDIT_FORM_INFO: EditInputTypes[] = [
+  {
+    formKey: 'title',
+    label: '제목',
+    maxLength: 12,
+    placeholder: '마일스톤 이름',
+  },
+  {
+    formKey: 'dueDate',
+    label: '완료일',
+    maxLength: 10,
+    placeholder: '완료일(선택) ex.YYYY-MM-DD',
+  },
+  {
+    formKey: 'description',
+    label: '설명',
+    maxLength: 30,
+    placeholder: '설명(선택)',
+  },
+];

--- a/src/components/Molecules/EditMilestone/index.styles.ts
+++ b/src/components/Molecules/EditMilestone/index.styles.ts
@@ -1,0 +1,37 @@
+import styled from 'styled-components';
+
+export const EditMilestone = styled.div`
+  width: 100%;
+  padding: 32px;
+  margin-bottom: 24px;
+  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+  border-radius: 16px;
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+
+  h2 {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_LARGE};
+    margin-bottom: 24px;
+  }
+`;
+
+export const EditForm = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+
+  div {
+    form {
+      width: 100%;
+    }
+    &:last-child {
+      grid-column: 1 / 3;
+    }
+  }
+`;
+
+export const EditButtons = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+`;

--- a/src/components/Molecules/EditMilestone/index.styles.ts
+++ b/src/components/Molecules/EditMilestone/index.styles.ts
@@ -1,17 +1,23 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
-export const EditMilestone = styled.div`
+export const EditMilestone = styled.div<{ editMode: 'ADD' | 'MODIFY' }>`
   width: 100%;
   padding: 32px;
-  margin-bottom: 24px;
-  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
-  border-radius: 16px;
   background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+  color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
 
   h2 {
     ${({ theme }) => theme.FONTSTYLES.TEXT_LARGE};
     margin-bottom: 24px;
   }
+
+  ${({ editMode }) =>
+    editMode === 'ADD' &&
+    css`
+      margin-bottom: 24px;
+      border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+      border-radius: 16px;
+    `}
 `;
 
 export const EditForm = styled.div`

--- a/src/components/Molecules/EditMilestone/index.tsx
+++ b/src/components/Molecules/EditMilestone/index.tsx
@@ -9,8 +9,8 @@ import { EDIT_FORM_INFO } from '@/components/Molecules/EditMilestone/constants';
 
 export interface MilestonesFormTypes {
   title: string;
-  description: string;
-  dueDate: string;
+  description: string | null;
+  dueDate: string | null;
 }
 
 interface EditMilestoneType {
@@ -38,14 +38,14 @@ const EditMilestone = ({ editMode, milestoneInfo }: EditMilestoneType) => {
   };
 
   return (
-    <S.EditMilestone>
+    <S.EditMilestone editMode={editMode}>
       <h2>{editMode === 'ADD' ? '새로운 마일스톤 추가' : '마일스톤 편집'}</h2>
       <S.EditForm>
         {EDIT_FORM_INFO.map((info) => (
           <EditInput
             key={info.formKey}
             {...info}
-            value={milestoneInfo && milestoneForm[info.formKey]}
+            value={(milestoneInfo && milestoneForm[info.formKey]) || ''}
             state={milestoneForm}
             setState={setMilestoneForm}
           />

--- a/src/components/Molecules/EditMilestone/index.tsx
+++ b/src/components/Molecules/EditMilestone/index.tsx
@@ -27,8 +27,8 @@ const INIT_FORM_STATE = {
   dueDate: '',
 };
 
-const EditMilestone = ({ id, editMode, milestoneInfo, setOpenState }: EditMilestoneType) => {
-  const { createMilestoneMutate } = useFetchMilestone();
+const EditMilestone = ({ editMode, milestoneInfo, id, setOpenState }: EditMilestoneType) => {
+  const { createMilestoneMutate, patchMilestoneDataMutate } = useFetchMilestone();
   const [milestoneForm, setMilestoneForm] = useState<MilestonesFormTypes>(milestoneInfo || INIT_FORM_STATE);
 
   const isDisabled = () => {
@@ -46,6 +46,16 @@ const EditMilestone = ({ id, editMode, milestoneInfo, setOpenState }: EditMilest
       createMilestoneMutate(milestoneForm);
       setOpenState((open) => !open);
     }
+
+    if (editMode === 'MODIFY') {
+      patchMilestoneDataMutate({ milestoneData: milestoneForm, id: id! });
+      setOpenState((open) => !open);
+    }
+  };
+
+  const onClickCancelButton = () => {
+    setMilestoneForm(milestoneInfo!);
+    setOpenState((open) => !open);
   };
 
   return (
@@ -63,9 +73,7 @@ const EditMilestone = ({ id, editMode, milestoneInfo, setOpenState }: EditMilest
         ))}
       </S.EditForm>
       <S.EditButtons>
-        {editMode === 'MODIFY' && (
-          <Button {...BUTTON_PROPS.CANCEL} handleOnClick={() => setMilestoneForm(milestoneInfo!)} />
-        )}
+        {editMode === 'MODIFY' && <Button {...BUTTON_PROPS.CANCEL} handleOnClick={onClickCancelButton} />}
         <Button {...BUTTON_PROPS.SAVE} disabled={isDisabled()} handleOnClick={onClickSaveButton} />
       </S.EditButtons>
     </S.EditMilestone>

--- a/src/components/Molecules/EditMilestone/index.tsx
+++ b/src/components/Molecules/EditMilestone/index.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import * as S from '@/components/Molecules/EditMilestone/index.styles';
 import Button from '@/components/Atoms/Button';
 import EditInput from '@/components/Molecules/EditMilestone/EditInput';
-
-import { BUTTON_PROPS } from '@/pages/Private/Milestones/constants';
 import { EDIT_FORM_INFO } from '@/components/Molecules/EditMilestone/constants';
+import { BUTTON_PROPS } from '@/pages/Private/Milestones/constants';
+
+import useFetchMilestone from '@/hooks/useFetchMilestone';
 
 export interface MilestonesFormTypes {
   title: string;
@@ -14,8 +15,10 @@ export interface MilestonesFormTypes {
 }
 
 interface EditMilestoneType {
+  id?: number;
   editMode: 'ADD' | 'MODIFY';
   milestoneInfo?: MilestonesFormTypes;
+  setOpenState: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const INIT_FORM_STATE = {
@@ -24,7 +27,8 @@ const INIT_FORM_STATE = {
   dueDate: '',
 };
 
-const EditMilestone = ({ editMode, milestoneInfo }: EditMilestoneType) => {
+const EditMilestone = ({ id, editMode, milestoneInfo, setOpenState }: EditMilestoneType) => {
+  const { createMilestoneMutate } = useFetchMilestone();
   const [milestoneForm, setMilestoneForm] = useState<MilestonesFormTypes>(milestoneInfo || INIT_FORM_STATE);
 
   const isDisabled = () => {
@@ -34,6 +38,13 @@ const EditMilestone = ({ editMode, milestoneInfo }: EditMilestoneType) => {
 
     if (editMode === 'MODIFY') {
       return JSON.stringify(milestoneForm) === JSON.stringify(milestoneInfo) || milestoneForm.title === '';
+    }
+  };
+
+  const onClickSaveButton = () => {
+    if (editMode === 'ADD') {
+      createMilestoneMutate(milestoneForm);
+      setOpenState((open) => !open);
     }
   };
 
@@ -55,7 +66,7 @@ const EditMilestone = ({ editMode, milestoneInfo }: EditMilestoneType) => {
         {editMode === 'MODIFY' && (
           <Button {...BUTTON_PROPS.CANCEL} handleOnClick={() => setMilestoneForm(milestoneInfo!)} />
         )}
-        <Button {...BUTTON_PROPS.SAVE} disabled={isDisabled()} />
+        <Button {...BUTTON_PROPS.SAVE} disabled={isDisabled()} handleOnClick={onClickSaveButton} />
       </S.EditButtons>
     </S.EditMilestone>
   );

--- a/src/components/Molecules/EditMilestone/index.tsx
+++ b/src/components/Molecules/EditMilestone/index.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+
+import * as S from '@/components/Molecules/EditMilestone/index.styles';
+import Button from '@/components/Atoms/Button';
+import EditInput from '@/components/Molecules/EditMilestone/EditInput';
+
+import { BUTTON_PROPS } from '@/pages/Private/Milestones/constants';
+import { EDIT_FORM_INFO } from '@/components/Molecules/EditMilestone/constants';
+
+export interface MilestonesFormTypes {
+  title: string;
+  description: string;
+  dueDate: string;
+}
+
+interface EditMilestoneType {
+  editMode: 'ADD' | 'MODIFY';
+  milestoneInfo?: MilestonesFormTypes;
+}
+
+const INIT_FORM_STATE = {
+  title: '',
+  description: '',
+  dueDate: '',
+};
+
+const EditMilestone = ({ editMode, milestoneInfo }: EditMilestoneType) => {
+  const [milestoneForm, setMilestoneForm] = useState<MilestonesFormTypes>(milestoneInfo || INIT_FORM_STATE);
+
+  const isDisabled = () => {
+    if (editMode === 'ADD') {
+      return milestoneForm.title === '';
+    }
+
+    if (editMode === 'MODIFY') {
+      return JSON.stringify(milestoneForm) === JSON.stringify(milestoneInfo) || milestoneForm.title === '';
+    }
+  };
+
+  return (
+    <S.EditMilestone>
+      <h2>{editMode === 'ADD' ? '새로운 마일스톤 추가' : '마일스톤 편집'}</h2>
+      <S.EditForm>
+        {EDIT_FORM_INFO.map((info) => (
+          <EditInput
+            key={info.formKey}
+            {...info}
+            value={milestoneInfo && milestoneForm[info.formKey]}
+            state={milestoneForm}
+            setState={setMilestoneForm}
+          />
+        ))}
+      </S.EditForm>
+      <S.EditButtons>
+        {editMode === 'MODIFY' && (
+          <Button {...BUTTON_PROPS.CANCEL} handleOnClick={() => setMilestoneForm(milestoneInfo!)} />
+        )}
+        <Button {...BUTTON_PROPS.SAVE} disabled={isDisabled()} />
+      </S.EditButtons>
+    </S.EditMilestone>
+  );
+};
+
+export default EditMilestone;

--- a/src/components/Molecules/FilterBar/index.styles.ts
+++ b/src/components/Molecules/FilterBar/index.styles.ts
@@ -28,9 +28,9 @@ export const FilterBarInput = styled.input<{ isActive: boolean }>`
   ${({ isActive }) =>
     isActive &&
     css`
-      color: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+      color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
 
       background: ${({ theme }) => theme.COLORS.OFF_WHITE};
-      border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+      border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
     `}
 `;

--- a/src/components/Molecules/IssueItem/index.styles.ts
+++ b/src/components/Molecules/IssueItem/index.styles.ts
@@ -3,8 +3,7 @@ import styled from 'styled-components';
 export const StyledIssueItem = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
   background: ${({ theme }) => theme.COLORS.OFF_WHITE};
-  height: 100px;
-  padding: 32px 24px;
+  padding: 24px 32px;
 
   .checkbox {
     margin-top: -35px;

--- a/src/components/Molecules/MilestoneItem/EmptyItem.tsx
+++ b/src/components/Molecules/MilestoneItem/EmptyItem.tsx
@@ -1,0 +1,9 @@
+import { CommonMilestoneItem } from './index.styles';
+
+const EmptyMilestoneItem = () => (
+  <CommonMilestoneItem>
+    <span>해당하는 마일스톤이 없습니다. 👀</span>
+  </CommonMilestoneItem>
+);
+
+export default EmptyMilestoneItem;

--- a/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
+++ b/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import MilestoneItem from '@/components/Molecules/MilestoneItem';
+
+export default {
+  title: 'Molecules/MilestoneItem',
+  component: MilestoneItem,
+} as ComponentMeta<typeof MilestoneItem>;
+
+const Template: ComponentStory<typeof MilestoneItem> = (args) => <MilestoneItem {...args} />;
+
+export const Initial = Template.bind({});
+Initial.args = {
+  id: 0,
+  title: '마일스톤 1주차',
+  description: '마일스톤 1주차에 대한 설명',
+  closeCount: 3,
+  openCount: 7,
+  dueDate: '2022-08-26',
+  closed: false,
+};
+
+export const OnlyTitle = Template.bind({});
+OnlyTitle.args = {
+  id: 1,
+  title: '타이틀만 있는 마일스톤',
+  description: null,
+  closeCount: 4,
+  openCount: 18,
+  dueDate: null,
+  closed: false,
+};

--- a/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
+++ b/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import MilestoneItem from '@/components/Molecules/MilestoneItem';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
 
 export default {
   title: 'Molecules/MilestoneItem',
@@ -19,6 +20,12 @@ Initial.args = {
   closed: false,
 };
 
+Initial.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
+  },
+};
+
 export const OnlyTitle = Template.bind({});
 OnlyTitle.args = {
   id: 1,
@@ -28,4 +35,10 @@ OnlyTitle.args = {
   openCount: 18,
   dueDate: null,
   closed: false,
+};
+
+OnlyTitle.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
+  },
 };

--- a/src/components/Molecules/MilestoneItem/constants.ts
+++ b/src/components/Molecules/MilestoneItem/constants.ts
@@ -1,0 +1,23 @@
+import { BUTTON_PROPS_TYPES } from '@/pages/Private/Milestones/constants';
+import { COLORS } from '@/styles/theme';
+
+export const MILESTONE_BUTTON_INFO: BUTTON_PROPS_TYPES = {
+  CLOSE: {
+    buttonStyle: 'NO_BORDER',
+    iconInfo: { icon: 'Archive' },
+    label: '닫기',
+    size: 'SMALL',
+  },
+  MODIFY: {
+    buttonStyle: 'NO_BORDER',
+    iconInfo: { icon: 'Edit' },
+    label: '편집',
+    size: 'SMALL',
+  },
+  DELETE: {
+    buttonStyle: 'NO_BORDER',
+    iconInfo: { icon: 'Trash', stroke: COLORS.ERROR.RED },
+    label: '삭제',
+    size: 'SMALL',
+  },
+};

--- a/src/components/Molecules/MilestoneItem/constants.ts
+++ b/src/components/Molecules/MilestoneItem/constants.ts
@@ -2,6 +2,12 @@ import { BUTTON_PROPS_TYPES } from '@/pages/Private/Milestones/constants';
 import { COLORS } from '@/styles/theme';
 
 export const MILESTONE_BUTTON_INFO: BUTTON_PROPS_TYPES = {
+  OPEN: {
+    buttonStyle: 'NO_BORDER',
+    iconInfo: { icon: 'Milestone', fill: COLORS.TITLE_ACTIVE },
+    label: '열기',
+    size: 'SMALL',
+  },
   CLOSE: {
     buttonStyle: 'NO_BORDER',
     iconInfo: { icon: 'Archive' },

--- a/src/components/Molecules/MilestoneItem/index.styles.ts
+++ b/src/components/Molecules/MilestoneItem/index.styles.ts
@@ -1,0 +1,76 @@
+import styled, { css } from 'styled-components';
+import { StyledIssueItem } from '@/components/Molecules/IssueItem/index.styles';
+
+export const MilestonItem = styled(StyledIssueItem)`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const MilestonItemInfo = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  align-items: baseline;
+
+  .MilestoneItem_title {
+    span {
+      ${({ theme }) => theme.FONTSTYLES.LINK_MEDIUM};
+      color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+      margin-left: 8px;
+    }
+  }
+
+  .MilestoneItem_dueDate {
+    display: flex;
+    align-items: center;
+    margin-left: 2px;
+    span {
+      ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+      color: ${({ theme }) => theme.COLORS.LABEL};
+      margin-left: 8px;
+    }
+  }
+
+  .MilestoneItem_description {
+    min-height: 28px;
+    grid-column: 1 / 3;
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+    color: ${({ theme }) => theme.COLORS.LABEL};
+  }
+`;
+
+export const MilestonItemButtons = styled.div<{ isOpenModifyEditer: boolean }>`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-end' })};
+  gap: 24px;
+
+  button {
+    :not(&:last-child):hover {
+      color: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+      svg {
+        stroke: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+      }
+    }
+
+    &:last-child {
+      color: ${({ theme }) => theme.COLORS.ERROR.RED};
+
+      &:hover {
+        color: ${({ theme }) => theme.COLORS.ERROR.DARK_RED};
+        svg {
+          stroke: ${({ theme }) => theme.COLORS.ERROR.DARK_RED};
+        }
+      }
+    }
+
+    ${({ isOpenModifyEditer }) =>
+      isOpenModifyEditer &&
+      css`
+        &:nth-child(2) {
+          color: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+          svg {
+            stroke: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+          }
+        }
+      `}
+  }
+`;

--- a/src/components/Molecules/MilestoneItem/index.styles.ts
+++ b/src/components/Molecules/MilestoneItem/index.styles.ts
@@ -1,12 +1,12 @@
 import styled, { css } from 'styled-components';
 import { StyledIssueItem } from '@/components/Molecules/IssueItem/index.styles';
 
-export const MilestonItem = styled(StyledIssueItem)`
+export const MilestoneItem = styled(StyledIssueItem)`
   display: flex;
   justify-content: space-between;
 `;
 
-export const MilestonItemInfo = styled.div`
+export const MilestoneItemInfo = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 8px;
@@ -39,7 +39,7 @@ export const MilestonItemInfo = styled.div`
   }
 `;
 
-export const MilestonItemButtons = styled.div<{ isOpenModifyEditer: boolean }>`
+export const MilestoneItemButtons = styled.div<{ isOpenModifyEditer: boolean }>`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-end' })};
   gap: 24px;
 

--- a/src/components/Molecules/MilestoneItem/index.styles.ts
+++ b/src/components/Molecules/MilestoneItem/index.styles.ts
@@ -6,6 +6,18 @@ export const MilestoneItem = styled(StyledIssueItem)`
   justify-content: space-between;
 `;
 
+export const CommonMilestoneItem = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+  padding: 24px 32px;
+
+  span {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
+    color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+    margin-left: 8px;
+  }
+`;
+
 export const MilestoneItemInfo = styled.div`
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -9,7 +9,7 @@ import EditMilestone from '@/components/Molecules/EditMilestone';
 import { MILESTONE_BUTTON_INFO } from '@/components/Molecules/MilestoneItem/constants';
 import { COLORS } from '@/styles/theme';
 
-interface MilestoneItemTypes {
+export interface MilestoneItemTypes {
   id: number;
   title: string;
   description: string | null;
@@ -50,6 +50,14 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
           <PrograssBar open={openCount} close={closeCount} showState />
         </div>
       </S.MilestoneItem>
+      {isOpenModifyEditer && (
+        <EditMilestone
+          editMode="MODIFY"
+          id={id}
+          milestoneInfo={{ title, description, dueDate }}
+          setOpenState={setIsOpenModifyEditer}
+        />
+      )}
     </>
   );
 };

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
+import { ModalState } from '@/components/Modal';
 
 import * as S from '@/components/Molecules/MilestoneItem/index.styles';
 import Button from '@/components/Atoms/Button';
@@ -9,6 +11,7 @@ import EditMilestone from '@/components/Molecules/EditMilestone';
 import { MILESTONE_BUTTON_INFO } from '@/components/Molecules/MilestoneItem/constants';
 import { COLORS } from '@/styles/theme';
 import useFetchMilestone from '@/hooks/useFetchMilestone';
+import { ClickMilestoneState } from '@/stores/milestone';
 
 export interface MilestoneItemTypes {
   id: number;
@@ -25,10 +28,12 @@ interface MilestoneItemCountTypes {
 }
 
 const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneItemTypes & MilestoneItemCountTypes) => {
-  const { patchMilestoneStateMutate, deleteMilestoneMutate } = useFetchMilestone();
+  const { patchMilestoneStateMutate } = useFetchMilestone();
 
   const { id, title, description, dueDate, closed } = props;
   const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
+  const setIsOpenModalState = useSetRecoilState(ModalState);
+  const setClickMilestoneState = useSetRecoilState(ClickMilestoneState);
 
   return (
     <>
@@ -51,7 +56,13 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
               handleOnClick={() => patchMilestoneStateMutate(id)}
             />
             <Button {...MILESTONE_BUTTON_INFO.MODIFY} handleOnClick={() => setIsOpenModifyEditer((state) => !state)} />
-            <Button {...MILESTONE_BUTTON_INFO.DELETE} handleOnClick={() => deleteMilestoneMutate(id)} />
+            <Button
+              {...MILESTONE_BUTTON_INFO.DELETE}
+              handleOnClick={() => {
+                setClickMilestoneState(props);
+                setIsOpenModalState((state) => !state);
+              }}
+            />
           </S.MilestoneItemButtons>
           <PrograssBar open={openCount} close={closeCount} showState />
         </div>

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -29,8 +29,8 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
 
   return (
     <>
-      <S.MilestonItem>
-        <S.MilestonItemInfo>
+      <S.MilestoneItem>
+        <S.MilestoneItemInfo>
           <Link to={`/milestone/${id}`} className="MilestoneItem_title">
             <Icon icon="Milestone" fill={COLORS.PRIMARY.BLUE} stroke={COLORS.PRIMARY.BLUE} />
             <span>{title}</span>
@@ -40,17 +40,16 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
             <span>{dueDate || '완료일 없음'}</span>
           </div>
           <p className="MilestoneItem_description">{description || ' '}</p>
-        </S.MilestonItemInfo>
+        </S.MilestoneItemInfo>
         <div>
-          <S.MilestonItemButtons isOpenModifyEditer={isOpenModifyEditer}>
+          <S.MilestoneItemButtons isOpenModifyEditer={isOpenModifyEditer}>
             <Button {...MILESTONE_BUTTON_INFO.CLOSE} />
             <Button {...MILESTONE_BUTTON_INFO.MODIFY} handleOnClick={() => setIsOpenModifyEditer((state) => !state)} />
             <Button {...MILESTONE_BUTTON_INFO.DELETE} />
-          </S.MilestonItemButtons>
+          </S.MilestoneItemButtons>
           <PrograssBar open={openCount} close={closeCount} showState />
         </div>
-      </S.MilestonItem>
-      {isOpenModifyEditer && <EditMilestone editMode="MODIFY" milestoneInfo={{ title, description, dueDate }} />}
+      </S.MilestoneItem>
     </>
   );
 };

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import * as S from '@/components/Molecules/MilestoneItem/index.styles';
+import Button from '@/components/Atoms/Button';
+import Icon from '@/components/Atoms/Icon';
+import PrograssBar from '@/components/Atoms/ProgressBar';
+import EditMilestone from '@/components/Molecules/EditMilestone';
+import { MILESTONE_BUTTON_INFO } from '@/components/Molecules/MilestoneItem/constants';
+import { COLORS } from '@/styles/theme';
+
+interface MilestoneItemTypes {
+  id: number;
+  title: string;
+  description: string | null;
+  dueDate: string | null;
+  closed: boolean;
+}
+
+// 아직 api에 해당 정보가 없어서 타입을 따로 분리해둠
+interface MilestoneItemCountTypes {
+  openCount?: number;
+  closeCount?: number;
+}
+
+const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneItemTypes & MilestoneItemCountTypes) => {
+  const { id, title, description, dueDate, closed } = props;
+  const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
+
+  return (
+    <>
+      <S.MilestonItem>
+        <S.MilestonItemInfo>
+          <Link to={`/milestone/${id}`} className="MilestoneItem_title">
+            <Icon icon="Milestone" fill={COLORS.PRIMARY.BLUE} stroke={COLORS.PRIMARY.BLUE} />
+            <span>{title}</span>
+          </Link>
+          <div className="MilestoneItem_dueDate">
+            <Icon icon="Calendar" stroke={COLORS.LABEL} />
+            <span>{dueDate || '완료일 없음'}</span>
+          </div>
+          <p className="MilestoneItem_description">{description || ' '}</p>
+        </S.MilestonItemInfo>
+        <div>
+          <S.MilestonItemButtons isOpenModifyEditer={isOpenModifyEditer}>
+            <Button {...MILESTONE_BUTTON_INFO.CLOSE} />
+            <Button {...MILESTONE_BUTTON_INFO.MODIFY} handleOnClick={() => setIsOpenModifyEditer((state) => !state)} />
+            <Button {...MILESTONE_BUTTON_INFO.DELETE} />
+          </S.MilestonItemButtons>
+          <PrograssBar open={openCount} close={closeCount} showState />
+        </div>
+      </S.MilestonItem>
+      {isOpenModifyEditer && <EditMilestone editMode="MODIFY" milestoneInfo={{ title, description, dueDate }} />}
+    </>
+  );
+};
+
+export default MilestoneItem;

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -8,6 +8,7 @@ import PrograssBar from '@/components/Atoms/ProgressBar';
 import EditMilestone from '@/components/Molecules/EditMilestone';
 import { MILESTONE_BUTTON_INFO } from '@/components/Molecules/MilestoneItem/constants';
 import { COLORS } from '@/styles/theme';
+import useFetchMilestone from '@/hooks/useFetchMilestone';
 
 export interface MilestoneItemTypes {
   id: number;
@@ -24,6 +25,8 @@ interface MilestoneItemCountTypes {
 }
 
 const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneItemTypes & MilestoneItemCountTypes) => {
+  const { deleteMilestoneMutate } = useFetchMilestone();
+
   const { id, title, description, dueDate, closed } = props;
   const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
 
@@ -45,7 +48,7 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
           <S.MilestoneItemButtons isOpenModifyEditer={isOpenModifyEditer}>
             <Button {...MILESTONE_BUTTON_INFO.CLOSE} />
             <Button {...MILESTONE_BUTTON_INFO.MODIFY} handleOnClick={() => setIsOpenModifyEditer((state) => !state)} />
-            <Button {...MILESTONE_BUTTON_INFO.DELETE} />
+            <Button {...MILESTONE_BUTTON_INFO.DELETE} handleOnClick={() => deleteMilestoneMutate(id)} />
           </S.MilestoneItemButtons>
           <PrograssBar open={openCount} close={closeCount} showState />
         </div>

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -25,7 +25,7 @@ interface MilestoneItemCountTypes {
 }
 
 const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneItemTypes & MilestoneItemCountTypes) => {
-  const { deleteMilestoneMutate } = useFetchMilestone();
+  const { patchMilestoneStateMutate, deleteMilestoneMutate } = useFetchMilestone();
 
   const { id, title, description, dueDate, closed } = props;
   const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
@@ -46,7 +46,10 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
         </S.MilestoneItemInfo>
         <div>
           <S.MilestoneItemButtons isOpenModifyEditer={isOpenModifyEditer}>
-            <Button {...MILESTONE_BUTTON_INFO.CLOSE} />
+            <Button
+              {...(closed ? MILESTONE_BUTTON_INFO.OPEN : MILESTONE_BUTTON_INFO.CLOSE)}
+              handleOnClick={() => patchMilestoneStateMutate(id)}
+            />
             <Button {...MILESTONE_BUTTON_INFO.MODIFY} handleOnClick={() => setIsOpenModifyEditer((state) => !state)} />
             <Button {...MILESTONE_BUTTON_INFO.DELETE} handleOnClick={() => deleteMilestoneMutate(id)} />
           </S.MilestoneItemButtons>

--- a/src/components/Molecules/NavLink/index.styles.ts
+++ b/src/components/Molecules/NavLink/index.styles.ts
@@ -43,7 +43,7 @@ export const StyledNavLink = styled(NavLink)`
   &.active {
     color: black;
     path {
-      stroke: ${({ theme }) => theme.COLORS.TITLE_ACVITE};
+      stroke: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
     }
   }
 `;

--- a/src/components/Organisms/MilestoneTable/Error/ErrorMilestoneTable.stories.tsx
+++ b/src/components/Organisms/MilestoneTable/Error/ErrorMilestoneTable.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
+import ErrorMilestoneTable from '@/components/Organisms/MilestoneTable/Error';
+
+export default {
+  title: 'Organisms/MilestoneTable/Error',
+  component: ErrorMilestoneTable,
+} as ComponentMeta<typeof ErrorMilestoneTable>;
+
+const Template: ComponentStory<typeof ErrorMilestoneTable> = (args) => <ErrorMilestoneTable {...args} />;
+
+export const Initial = Template.bind({});
+
+Initial.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
+  },
+};

--- a/src/components/Organisms/MilestoneTable/Error/index.styles.ts
+++ b/src/components/Organisms/MilestoneTable/Error/index.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { CommonMilestoneItem } from '@/components/Molecules/MilestoneItem/index.styles';
+import { IssueHeader } from '@/components/Organisms/IssueTable/index.styles';
+
+export const ErrorMilestoneHeader = styled(IssueHeader)`
+  gap: 20px;
+`;
+
+export const ErrordMilestoneItem = styled(CommonMilestoneItem)`
+  button {
+    margin-left: 12px;
+    border-radius: 8px;
+    width: fit-content;
+    height: 32px;
+    background: ${({ theme }) => theme.COLORS.PLACEHOLDER};
+
+    &:active:not([disabled]) {
+      border: none;
+      background: ${({ theme }) => theme.COLORS.PRIMARY.LIGHT_BLUE};
+      color: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+
+      svg {
+        stroke: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
+      }
+    }
+  }
+`;

--- a/src/components/Organisms/MilestoneTable/Error/index.tsx
+++ b/src/components/Organisms/MilestoneTable/Error/index.tsx
@@ -1,0 +1,32 @@
+import * as S from '@/components/Organisms/MilestoneTable/Error/index.styles';
+import Button from '@/components/Atoms/Button';
+import { StyledIssueTable as StyledErrorMilestoneTable } from '@/components/Organisms/IssueTable/index.styles';
+import { COLORS } from '@/styles/theme';
+
+const ErrorMilestoneItem = ({ handleOnClick }: { handleOnClick: () => void }) => (
+  <S.ErrordMilestoneItem>
+    <span>앗! 데이터를 불러오는데 실패했어요...</span>
+    <Button
+      buttonStyle="STANDARD"
+      iconInfo={{
+        icon: 'RefreshCcw',
+        stroke: COLORS.OFF_WHITE,
+      }}
+      label="다시 시도"
+      size="SMALL"
+      handleOnClick={handleOnClick}
+    />
+  </S.ErrordMilestoneItem>
+);
+
+const ErrorMilestoneTable = ({ resetErrorBoundary }: { resetErrorBoundary: (...args: Array<unknown>) => void }) => (
+  <StyledErrorMilestoneTable>
+    <S.ErrorMilestoneHeader>
+      <div>열린 마일스톤 (x)</div>
+      <div>닫힌 마일스톤 (x)</div>
+    </S.ErrorMilestoneHeader>
+    <ErrorMilestoneItem handleOnClick={resetErrorBoundary} />
+  </StyledErrorMilestoneTable>
+);
+
+export default ErrorMilestoneTable;

--- a/src/components/Organisms/MilestoneTable/MilestoneTable.stories.tsx
+++ b/src/components/Organisms/MilestoneTable/MilestoneTable.stories.tsx
@@ -1,0 +1,34 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import MilestoneTable, { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
+
+export default {
+  title: 'Organisms/MilestoneTable',
+  component: MilestoneTable,
+} as ComponentMeta<typeof MilestoneTable>;
+
+const Template: ComponentStory<typeof MilestoneTable> = (args) => <MilestoneTable {...args} />;
+
+const MILESTONE_DATA: MilestoneListTypes = {
+  openedMilestones: [
+    {
+      id: 0,
+      title: '마일스톤 1',
+      description: null,
+      dueDate: '2022-09-11',
+      closed: false,
+    },
+    {
+      id: 1,
+      title: '마일스톤 2',
+      description: '열린 마일스톤에 대한 설명',
+      dueDate: null,
+      closed: true,
+    },
+  ],
+  closedMilestones: [],
+};
+
+export const Initial = Template.bind({});
+Initial.args = {
+  milestoneData: MILESTONE_DATA,
+};

--- a/src/components/Organisms/MilestoneTable/MilestoneTable.stories.tsx
+++ b/src/components/Organisms/MilestoneTable/MilestoneTable.stories.tsx
@@ -1,5 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import MilestoneTable, { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
 
 export default {
   title: 'Organisms/MilestoneTable',
@@ -31,4 +32,10 @@ const MILESTONE_DATA: MilestoneListTypes = {
 export const Initial = Template.bind({});
 Initial.args = {
   milestoneData: MILESTONE_DATA,
+};
+
+Initial.parameters = {
+  msw: {
+    handlers: milestoneHandlers,
+  },
 };

--- a/src/components/Organisms/MilestoneTable/index.tsx
+++ b/src/components/Organisms/MilestoneTable/index.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable react/prop-types */
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import {
+  StyledIssueTable as StyledMilestoneTable,
+  IssueHeader as StyledMilestoneHeader,
+} from '@/components/Organisms/IssueTable/index.styles';
+import Icon from '@/components/Atoms/Icon';
+import NavLink from '@/components/Molecules/NavLink';
+import MilestoneItem, { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
+import EmptyMilestoneItem from '@/components/Molecules/MilestoneItem/EmptyItem';
+
+export interface MilestoneListTypes {
+  closedMilestones: MilestoneItemTypes[];
+  openedMilestones: MilestoneItemTypes[];
+}
+
+const MILESTONE_STATE_TAB = (data: MilestoneListTypes) => [
+  {
+    icon: <Icon icon="Milestone" fill="#14142B" stroke="#ffffff" />,
+    link: '/milestone?state=open',
+    title: `열린 마일스톤(${data.openedMilestones.length})`,
+  },
+  {
+    icon: <Icon icon="Archive" stroke="#14142B" />,
+    link: '/milestone?state=closed',
+    title: `닫힌 마일스톤(${data.closedMilestones.length})`,
+  },
+];
+
+const MilestoneTable = ({ milestoneData }: { milestoneData: MilestoneListTypes }) => {
+  const [searchParams] = useSearchParams();
+  const stateParam = searchParams.get('state');
+
+  const isOpenMilestone = () => {
+    if (!stateParam || stateParam === 'open') return true;
+    if (stateParam === 'closed') return false;
+  };
+
+  const renderMilestones = (milestoneList: MilestoneItemTypes[]) => {
+    if (milestoneList.length) {
+      return milestoneList.map((info) => <MilestoneItem key={info.id} {...info} />);
+    }
+
+    return <EmptyMilestoneItem />;
+  };
+
+  useEffect(() => {}, [searchParams]);
+
+  return (
+    <StyledMilestoneTable>
+      <StyledMilestoneHeader>
+        <NavLink navData={MILESTONE_STATE_TAB(milestoneData)} />
+      </StyledMilestoneHeader>
+      {isOpenMilestone()
+        ? renderMilestones(milestoneData.openedMilestones)
+        : renderMilestones(milestoneData.closedMilestones)}
+    </StyledMilestoneTable>
+  );
+};
+
+export default MilestoneTable;

--- a/src/components/Organisms/MilestoneTable/index.tsx
+++ b/src/components/Organisms/MilestoneTable/index.tsx
@@ -4,6 +4,12 @@ import { useSearchParams } from 'react-router-dom';
 import { ErrorBoundary } from 'react-error-boundary';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { ClickMilestoneState } from '@/stores/milestone';
+import ModalPortal from '@/Portal';
+import Modal, { ModalState } from '@/components/Modal';
+import DeleteMilestoneModal from '@/components/Modal/DeleteMilestone';
+
 import {
   StyledIssueTable as StyledMilestoneTable,
   IssueHeader as StyledMilestoneHeader,
@@ -38,6 +44,9 @@ const MILESTONE_STATE_TAB = (data: MilestoneListTypes) => [
 
 const MilestoneTable = () => {
   const { milestoneData } = useFetchMilestone();
+  const [isOpenModalState] = useRecoilState(ModalState);
+  const clickMilestoneState = useRecoilValue(ClickMilestoneState);
+
   const [searchParams] = useSearchParams();
   const stateParam = searchParams.get('state');
 
@@ -57,14 +66,24 @@ const MilestoneTable = () => {
   useEffect(() => {}, [searchParams]);
 
   return (
-    <StyledMilestoneTable>
-      <StyledMilestoneHeader>
-        <NavLink navData={MILESTONE_STATE_TAB(milestoneData!)} />
-      </StyledMilestoneHeader>
-      {isOpenMilestone()
-        ? renderMilestones(milestoneData!.openedMilestones)
-        : renderMilestones(milestoneData!.closedMilestones)}
-    </StyledMilestoneTable>
+    <>
+      <StyledMilestoneTable>
+        <StyledMilestoneHeader>
+          <NavLink navData={MILESTONE_STATE_TAB(milestoneData!)} />
+        </StyledMilestoneHeader>
+        {isOpenMilestone()
+          ? renderMilestones(milestoneData!.openedMilestones)
+          : renderMilestones(milestoneData!.closedMilestones)}
+      </StyledMilestoneTable>
+      {isOpenModalState && (
+        <ModalPortal>
+          <Modal>
+            <DeleteMilestoneModal id={clickMilestoneState.id} />
+          </Modal>
+          )
+        </ModalPortal>
+      )}
+    </>
   );
 };
 

--- a/src/components/Skeleton/MilestoneTable/SkeletonMilestoneTable.stories.tsx
+++ b/src/components/Skeleton/MilestoneTable/SkeletonMilestoneTable.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SkeletonMilestoneTable from '@/components/Skeleton/MilestoneTable';
+
+export default {
+  title: 'Skeleton/MilestoneTable',
+  component: SkeletonMilestoneTable,
+} as ComponentMeta<typeof SkeletonMilestoneTable>;
+
+const Template: ComponentStory<typeof SkeletonMilestoneTable> = () => <SkeletonMilestoneTable />;
+
+export const Initial = Template.bind({});

--- a/src/components/Skeleton/MilestoneTable/index.styles.ts
+++ b/src/components/Skeleton/MilestoneTable/index.styles.ts
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+import { MilestoneItem } from '@/components/Molecules/MilestoneItem/index.styles';
+import { COLORS } from '@/styles/theme';
+
+const skeletonRectangle = (width: number, height: number) => `
+  position: relative;
+  overflow: hidden;
+  border-radius: 8px;
+  width: ${width}px;
+  height: ${height}px;
+  background: ${COLORS.LINE};
+
+  @keyframes loading {
+    0% {
+      transform: translateX(0);
+    }
+    50%,
+    100% {
+      transform: translateX(400px);
+    }
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 30px;
+    height: 100%;
+    background: linear-gradient(to right, #d9dbe9, #e8e9f1, #d9dbe9);
+    animation: loading 3s infinite linear;
+  }
+`;
+
+export const SkeletonNavLink = styled.div`
+  ${skeletonRectangle(300, 32)}
+`;
+
+export const SkeletonMilestoneItem = styled(MilestoneItem)`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'space-between' })};
+`;
+
+export const SkeletonMilestoneItemInfo = styled.div`
+  .skeleton_milestone__item {
+    ${skeletonRectangle(200, 24)}
+    margin-bottom: 16px;
+  }
+
+  .skeleton_milestone__desc {
+    ${skeletonRectangle(300, 20)}
+  }
+`;
+
+export const SkeletonMilestoneItemStates = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ direction: 'column', align: 'flex-end' })};
+
+  .skeleton_milestone__buttons {
+    ${skeletonRectangle(180, 24)}
+    margin-bottom: 10px;
+  }
+
+  .skeleton_milestone__progress {
+    ${skeletonRectangle(244, 50)}
+  }
+`;
+
+export {
+  StyledIssueTable as MilestoneTable,
+  IssueHeader as MilestoneHeader,
+} from '@/components/Organisms/IssueTable/index.styles';

--- a/src/components/Skeleton/MilestoneTable/index.tsx
+++ b/src/components/Skeleton/MilestoneTable/index.tsx
@@ -1,0 +1,31 @@
+import * as S from '@/components/Skeleton/MilestoneTable/index.styles';
+
+const SkeletonMilestoneItem = (): JSX.Element => (
+  <S.SkeletonMilestoneItem>
+    <S.SkeletonMilestoneItemInfo>
+      <div className="skeleton_milestone__item" />
+      <div className="skeleton_milestone__desc" />
+    </S.SkeletonMilestoneItemInfo>
+    <S.SkeletonMilestoneItemStates>
+      <div className="skeleton_milestone__buttons" />
+      <div className="skeleton_milestone__progress" />
+    </S.SkeletonMilestoneItemStates>
+  </S.SkeletonMilestoneItem>
+);
+
+const SkeletonMilestoneTable = () => {
+  const MilestoneItems = Array.from(['item1', 'item2', 'item3', 'items4']).map((key) => (
+    <SkeletonMilestoneItem key={`skeletonItems-${key}`} />
+  ));
+
+  return (
+    <S.MilestoneTable>
+      <S.MilestoneHeader>
+        <S.SkeletonNavLink />
+      </S.MilestoneHeader>
+      {MilestoneItems}
+    </S.MilestoneTable>
+  );
+};
+
+export default SkeletonMilestoneTable;

--- a/src/hooks/useFetchMilestone.ts
+++ b/src/hooks/useFetchMilestone.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getMilestoneData, createNewMilestone, patchMilestoneData } from '@/api/milestone';
+import { getMilestoneData, createNewMilestone, patchMilestoneData, deleteMilestone } from '@/api/milestone';
 import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
 
 const useFetchMilestone = () => {
@@ -21,10 +21,17 @@ const useFetchMilestone = () => {
     },
   });
 
+  const { mutate: deleteMilestoneMutate } = useMutation(deleteMilestone, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['milestones']);
+    },
+  });
+
   return {
     milestoneData,
     createMilestoneMutate,
     patchMilestoneDataMutate,
+    deleteMilestoneMutate,
   };
 };
 

--- a/src/hooks/useFetchMilestone.ts
+++ b/src/hooks/useFetchMilestone.ts
@@ -1,5 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getMilestoneData, createNewMilestone, patchMilestoneData, deleteMilestone } from '@/api/milestone';
+import {
+  getMilestoneData,
+  createNewMilestone,
+  patchMilestoneData,
+  patchMilestoneState,
+  deleteMilestone,
+} from '@/api/milestone';
 import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
 
 const useFetchMilestone = () => {
@@ -21,6 +27,12 @@ const useFetchMilestone = () => {
     },
   });
 
+  const { mutate: patchMilestoneStateMutate } = useMutation(patchMilestoneState, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['milestones']);
+    },
+  });
+
   const { mutate: deleteMilestoneMutate } = useMutation(deleteMilestone, {
     onSuccess: () => {
       queryClient.invalidateQueries(['milestones']);
@@ -31,6 +43,7 @@ const useFetchMilestone = () => {
     milestoneData,
     createMilestoneMutate,
     patchMilestoneDataMutate,
+    patchMilestoneStateMutate,
     deleteMilestoneMutate,
   };
 };

--- a/src/hooks/useFetchMilestone.ts
+++ b/src/hooks/useFetchMilestone.ts
@@ -1,14 +1,23 @@
-import { useQuery } from '@tanstack/react-query';
-import { getMilestoneData } from '@/api/milestone';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getMilestoneData, createNewMilestone } from '@/api/milestone';
 import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
 
 const useFetchMilestone = () => {
+  const queryClient = useQueryClient();
+
   const { data: milestoneData } = useQuery<MilestoneListTypes>(['milestones'], getMilestoneData, {
     useErrorBoundary: true,
   });
 
+  const { mutate: createMilestoneMutate } = useMutation(createNewMilestone, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['milestones']);
+    },
+  });
+
   return {
     milestoneData,
+    createMilestoneMutate,
   };
 };
 

--- a/src/hooks/useFetchMilestone.ts
+++ b/src/hooks/useFetchMilestone.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getMilestoneData, createNewMilestone } from '@/api/milestone';
+import { getMilestoneData, createNewMilestone, patchMilestoneData } from '@/api/milestone';
 import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
 
 const useFetchMilestone = () => {
@@ -15,9 +15,16 @@ const useFetchMilestone = () => {
     },
   });
 
+  const { mutate: patchMilestoneDataMutate } = useMutation(patchMilestoneData, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['milestones']);
+    },
+  });
+
   return {
     milestoneData,
     createMilestoneMutate,
+    patchMilestoneDataMutate,
   };
 };
 

--- a/src/hooks/useFetchMilestone.ts
+++ b/src/hooks/useFetchMilestone.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { getMilestoneData } from '@/api/milestone';
+import { MilestoneListTypes } from '@/components/Organisms/MilestoneTable';
+
+const useFetchMilestone = () => {
+  const { data: milestoneData } = useQuery<MilestoneListTypes>(['milestones'], getMilestoneData, {
+    useErrorBoundary: true,
+  });
+
+  return {
+    milestoneData,
+  };
+};
+
+export default useFetchMilestone;

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -93,4 +93,25 @@ export const milestoneHandlers = [
 
     return res(ctx.status(400), ctx.json(false));
   }),
+
+  rest.delete('api/milestones/:id', async (req, res, ctx) => {
+    const { id } = req.params;
+
+    const deleteMilestones = Object.values(milestones).map((state: MilestoneItemTypes[]) => {
+      if (state.find((el) => el.id === Number(id))) {
+        return state.filter((el) => el.id !== Number(id));
+      }
+      return state;
+    });
+
+    const [newOpenedMilestones, newClosedMilestones] = deleteMilestones;
+    milestones.openedMilestones = newOpenedMilestones;
+    milestones.closedMilestones = newClosedMilestones;
+
+    if (req.cookies['refresh-token']) {
+      return res(ctx.status(200), ctx.json({ message: '성공적으로 삭제되었습니다.' }));
+    }
+
+    return res(ctx.status(400), ctx.json(tokenErrorMessage));
+  }),
 ];

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -55,11 +55,11 @@ export const milestoneHandlers = [
     }
 
     const newMilestone = {
-      id: milestones.openedMilestones.length + 1,
+      id: title.charCodeAt(title.length - 1) + Math.floor(Math.random() * 10000),
       title,
       description,
       dueDate,
-      closed: true,
+      closed: false,
     };
 
     milestones.openedMilestones.push(newMilestone);
@@ -89,6 +89,38 @@ export const milestoneHandlers = [
 
     if (req.cookies['refresh-token']) {
       return res(ctx.status(200), ctx.json(patchMilestones));
+    }
+
+    return res(ctx.status(400), ctx.json(false));
+  }),
+
+  rest.patch('api/milestones/:id/status', async (req, res, ctx) => {
+    const { id } = req.params;
+
+    const find = () => {
+      const result: MilestoneItemTypes[] = [];
+      Object.values(milestones).forEach((state: MilestoneItemTypes[]) => {
+        const findMilestone = state.find((el) => el.id === Number(id));
+        if (findMilestone) {
+          result.push(findMilestone);
+        }
+      });
+
+      return result[0];
+    };
+
+    const milestone = find();
+
+    if (milestone.closed) {
+      milestones.openedMilestones.push({ ...milestone, closed: false });
+      milestones.closedMilestones = milestones.closedMilestones.filter((el) => el.id !== Number(id));
+    } else {
+      milestones.closedMilestones.push({ ...milestone, closed: true });
+      milestones.openedMilestones = milestones.openedMilestones.filter((el) => el.id !== Number(id));
+    }
+
+    if (req.cookies['refresh-token']) {
+      return res(ctx.status(200), ctx.json(milestones));
     }
 
     return res(ctx.status(400), ctx.json(false));

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -41,8 +41,8 @@ export const milestoneHandlers = [
   }),
 
   rest.post('api/milestones', async (req, res, ctx) => {
-    const newMilestone = await req.json();
-    const { title, description, dueDate } = newMilestone;
+    const requestData = await req.json();
+    const { title, description, dueDate } = requestData;
 
     if (!title) {
       return res(ctx.status(400), ctx.json('필수 입력값을 입력해주세요'));
@@ -52,9 +52,7 @@ export const milestoneHandlers = [
       return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
     }
 
-    milestones.openedMilestones.push(newMilestone);
-
-    const response = {
+    const newMilestone = {
       id: milestones.openedMilestones.length + 1,
       title,
       description,
@@ -62,6 +60,14 @@ export const milestoneHandlers = [
       closed: true,
     };
 
+    milestones.openedMilestones.push(newMilestone);
+
+    if (req.cookies['refresh-token']) {
+      return res(ctx.status(200), ctx.json(newMilestone));
+    }
+
+    return res(ctx.status(400), ctx.json(tokenErrorMessage));
+  }),
     if (req.cookies['refresh-token']) {
       return res(ctx.status(200), ctx.json(response));
     }

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -1,0 +1,40 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { rest } from 'msw';
+
+const milestones = {
+  openedMilestones: [
+    {
+      id: 0,
+      title: '마일스톤 1',
+      description: null,
+      dueDate: null,
+      closed: false,
+    },
+    {
+      id: 2,
+      title: '마일스톤 3',
+      description: '열린 마일스톤에 대한 설명',
+      dueDate: '2022-08-28',
+      closed: false,
+    },
+  ],
+  closedMilestones: [
+    {
+      id: 1,
+      title: '마일스톤 2',
+      description: '닫힌 마일스톤에 대한 설명',
+      dueDate: null,
+      closed: true,
+    },
+  ],
+};
+
+export const milestoneHandlers = [
+  rest.get('api/milestones', (req, res, ctx) => {
+    if (req.cookies['refresh-token']) {
+      return res(ctx.status(200), ctx.json(milestones));
+    }
+
+    return res(ctx.status(400), ctx.json(false));
+  }),
+];

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -34,13 +34,13 @@ const milestones: MilestoneListTypes = {
 };
 
 export const milestoneHandlers = [
-  rest.get('api/milestones', (req, res, ctx) => {
-    if (req.cookies['refresh-token']) {
-      return res(ctx.status(200), ctx.json(milestones));
-    }
+  rest.get('api/milestones', (req, res, ctx) =>
+    // if (!req.cookies['refresh-token']) {
+    //   return res(ctx.status(400), ctx.json(false));
+    // }
 
-    return res(ctx.status(400), ctx.json(false));
-  }),
+    res(ctx.status(200), ctx.json(milestones)),
+  ),
 
   rest.post('api/milestones', async (req, res, ctx) => {
     const requestData = await req.json();
@@ -50,9 +50,9 @@ export const milestoneHandlers = [
       return res(ctx.status(400), ctx.json('필수 입력값을 입력해주세요'));
     }
 
-    if (!req.cookies['refresh-token']) {
-      return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
-    }
+    // if (!req.cookies['refresh-token']) {
+    //   return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
+    // }
 
     const newMilestone = {
       id: title.charCodeAt(title.length - 1) + Math.floor(Math.random() * 10000),
@@ -64,11 +64,7 @@ export const milestoneHandlers = [
 
     milestones.openedMilestones.push(newMilestone);
 
-    if (req.cookies['refresh-token']) {
-      return res(ctx.status(200), ctx.json(newMilestone));
-    }
-
-    return res(ctx.status(400), ctx.json(tokenErrorMessage));
+    return res(ctx.status(200), ctx.json(newMilestone));
   }),
 
   rest.patch('api/milestones/:id', async (req, res, ctx) => {
@@ -87,11 +83,11 @@ export const milestoneHandlers = [
     milestones.openedMilestones = newOpenedMilestones;
     milestones.closedMilestones = newClosedMilestones;
 
-    if (req.cookies['refresh-token']) {
-      return res(ctx.status(200), ctx.json(patchMilestones));
-    }
+    // if (!req.cookies['refresh-token']) {
+    //   return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
+    // }
 
-    return res(ctx.status(400), ctx.json(false));
+    return res(ctx.status(200), ctx.json(patchMilestones));
   }),
 
   rest.patch('api/milestones/:id/status', async (req, res, ctx) => {
@@ -119,11 +115,11 @@ export const milestoneHandlers = [
       milestones.openedMilestones = milestones.openedMilestones.filter((el) => el.id !== Number(id));
     }
 
-    if (req.cookies['refresh-token']) {
-      return res(ctx.status(200), ctx.json(milestones));
-    }
+    // if (!req.cookies['refresh-token']) {
+    //   return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
+    // }
 
-    return res(ctx.status(400), ctx.json(false));
+    return res(ctx.status(200), ctx.json(milestones));
   }),
 
   rest.delete('api/milestones/:id', async (req, res, ctx) => {
@@ -140,10 +136,11 @@ export const milestoneHandlers = [
     milestones.openedMilestones = newOpenedMilestones;
     milestones.closedMilestones = newClosedMilestones;
 
-    if (req.cookies['refresh-token']) {
-      return res(ctx.status(200), ctx.json({ message: '성공적으로 삭제되었습니다.' }));
-    }
+    // if (!req.cookies['refresh-token']) {
+    //   console.log(!req.cookies['refresh-token']);
+    //   return res(ctx.status(400), ctx.json(tokenErrorMessage.message));
+    // }
 
-    return res(ctx.status(400), ctx.json(tokenErrorMessage));
+    return res(ctx.status(200), ctx.json({ message: '성공적으로 삭제되었습니다.' }));
   }),
 ];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,4 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
 import { setupServer } from 'msw/node';
-import { handlers } from './handlers';
+import { handlers } from '@/mocks/handlers';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
 
-export const server = setupServer(...handlers);
+export const server = setupServer(...handlers, ...milestoneHandlers);

--- a/src/mocks/worker.ts
+++ b/src/mocks/worker.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { setupWorker } from 'msw';
-import { handlers } from './handlers';
+import { handlers } from '@/mocks/handlers';
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers, ...milestoneHandlers);

--- a/src/pages/Private/Milestones/MilestonesPage.stories.tsx
+++ b/src/pages/Private/Milestones/MilestonesPage.stories.tsx
@@ -1,13 +1,13 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import MilestoneTable from '@/components/Organisms/MilestoneTable';
 import { milestoneHandlers } from '@/mocks/handlers/milestones';
+import Milestones from '.';
 
 export default {
-  title: 'Organisms/MilestoneTable',
-  component: MilestoneTable,
-} as ComponentMeta<typeof MilestoneTable>;
+  title: 'Pages/Milestones',
+  component: Milestones,
+} as ComponentMeta<typeof Milestones>;
 
-const Template: ComponentStory<typeof MilestoneTable> = () => <MilestoneTable />;
+const Template: ComponentStory<typeof Milestones> = () => <Milestones />;
 
 export const Initial = Template.bind({});
 

--- a/src/pages/Private/Milestones/constants.tsx
+++ b/src/pages/Private/Milestones/constants.tsx
@@ -1,0 +1,59 @@
+import Icon from '@/components/Atoms/Icon';
+import { ButtonTypes } from '@/components/Atoms/Button';
+import { COLORS } from '@/styles/theme';
+
+interface BUTTON_PROPS_TYPES {
+  [key: string]: ButtonTypes;
+}
+
+export const BUTTON_PROPS: BUTTON_PROPS_TYPES = {
+  ADD: {
+    label: '추가',
+    size: 'SMALL',
+    buttonStyle: 'STANDARD',
+    iconInfo: {
+      icon: 'Plus',
+      stroke: COLORS.OFF_WHITE,
+    },
+  },
+  CLOSE: {
+    label: '닫기',
+    size: 'SMALL',
+    buttonStyle: 'SECONDARY',
+    iconInfo: {
+      icon: 'XSquare',
+      stroke: COLORS.PRIMARY.BLUE,
+    },
+  },
+  SAVE: {
+    label: '완료',
+    size: 'SMALL',
+    buttonStyle: 'STANDARD',
+    iconInfo: {
+      icon: 'Plus',
+      stroke: COLORS.OFF_WHITE,
+    },
+  },
+  CANCEL: {
+    label: '취소',
+    size: 'SMALL',
+    buttonStyle: 'SECONDARY',
+    iconInfo: {
+      icon: 'XSquare',
+      stroke: COLORS.PRIMARY.BLUE,
+    },
+  },
+};
+
+export const NAV_DATA = [
+  {
+    icon: <Icon icon="Tag" stroke="#14142B" />,
+    link: '/label',
+    title: '레이블 (3)',
+  },
+  {
+    icon: <Icon icon="Milestone" fill="#14142B" />,
+    link: '/milestone',
+    title: '마일스톤 (2)',
+  },
+];

--- a/src/pages/Private/Milestones/constants.tsx
+++ b/src/pages/Private/Milestones/constants.tsx
@@ -2,7 +2,7 @@ import Icon from '@/components/Atoms/Icon';
 import { ButtonTypes } from '@/components/Atoms/Button';
 import { COLORS } from '@/styles/theme';
 
-interface BUTTON_PROPS_TYPES {
+export interface BUTTON_PROPS_TYPES {
   [key: string]: ButtonTypes;
 }
 

--- a/src/pages/Private/Milestones/constants.tsx
+++ b/src/pages/Private/Milestones/constants.tsx
@@ -49,11 +49,11 @@ export const NAV_DATA = [
   {
     icon: <Icon icon="Tag" stroke="#14142B" />,
     link: '/label',
-    title: '레이블 (3)',
+    title: '레이블',
   },
   {
     icon: <Icon icon="Milestone" fill="#14142B" />,
     link: '/milestone',
-    title: '마일스톤 (2)',
+    title: '마일스톤',
   },
 ];

--- a/src/pages/Private/Milestones/index.tsx
+++ b/src/pages/Private/Milestones/index.tsx
@@ -4,6 +4,7 @@ import { LoginUserInfoState } from '@/stores/loginUserInfo';
 
 import styled from 'styled-components';
 import Button from '@/components/Atoms/Button';
+import EditMileStone from '@/components/Molecules/EditMilestone';
 import NavLink from '@/components/Molecules/NavLink';
 import Header from '@/components/Organisms/Header';
 
@@ -16,7 +17,7 @@ const NavContainer = styled.div`
 
 const Milestones = () => {
   const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
-  const [isOpenAddEdit, setIsOpenAddEdit] = useState(true);
+  const [isOpenAddEdit, setIsOpenAddEdit] = useState(false);
 
   const openAddEdit = () => {
     setIsOpenAddEdit((state) => !state);
@@ -29,6 +30,7 @@ const Milestones = () => {
         <NavLink navData={NAV_DATA} navLinkStyle="LINE" />
         <Button {...(isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
       </NavContainer>
+      {!isOpenAddEdit && <EditMileStone editMode="ADD" />}
     </div>
   );
 };

--- a/src/pages/Private/Milestones/index.tsx
+++ b/src/pages/Private/Milestones/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useState } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
 
@@ -38,7 +38,7 @@ const Milestones = () => {
         <NavLink navData={NAV_DATA} navLinkStyle="LINE" />
         <Button {...(!isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
       </NavContainer>
-      {isOpenAddEdit && <EditMilestone editMode="ADD" />}
+      {isOpenAddEdit && <EditMilestone editMode="ADD" setOpenState={setIsOpenAddEdit} />}
       <Suspense fallback={<SkeletonMilestoneTable />}>
         <MilestoneTable milestoneData={milestoneData!} />
       </Suspense>

--- a/src/pages/Private/Milestones/index.tsx
+++ b/src/pages/Private/Milestones/index.tsx
@@ -1,14 +1,20 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
 
 import styled from 'styled-components';
 import Button from '@/components/Atoms/Button';
-import EditMileStone from '@/components/Molecules/EditMilestone';
+import EditMilestone from '@/components/Molecules/EditMilestone';
 import NavLink from '@/components/Molecules/NavLink';
 import Header from '@/components/Organisms/Header';
 
+import SkeletonMilestoneTable from '@/components/Skeleton/MilestoneTable';
+
 import { BUTTON_PROPS, NAV_DATA } from '@/pages/Private/Milestones/constants';
+
+import useFetchMilestone from '@/hooks/useFetchMilestone';
+
+const MilestoneTable = lazy(() => import('@/components/Organisms/MilestoneTable'));
 
 const NavContainer = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'space-between' })};
@@ -19,6 +25,8 @@ const Milestones = () => {
   const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
   const [isOpenAddEdit, setIsOpenAddEdit] = useState(false);
 
+  const { milestoneData } = useFetchMilestone();
+
   const openAddEdit = () => {
     setIsOpenAddEdit((state) => !state);
   };
@@ -28,9 +36,12 @@ const Milestones = () => {
       <Header user={LoginUserInfoStateValue} />
       <NavContainer>
         <NavLink navData={NAV_DATA} navLinkStyle="LINE" />
-        <Button {...(isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
+        <Button {...(!isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
       </NavContainer>
-      {!isOpenAddEdit && <EditMileStone editMode="ADD" />}
+      {isOpenAddEdit && <EditMilestone editMode="ADD" />}
+      <Suspense fallback={<SkeletonMilestoneTable />}>
+        <MilestoneTable milestoneData={milestoneData!} />
+      </Suspense>
     </div>
   );
 };

--- a/src/pages/Private/Milestones/index.tsx
+++ b/src/pages/Private/Milestones/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
 
@@ -8,13 +8,8 @@ import EditMilestone from '@/components/Molecules/EditMilestone';
 import NavLink from '@/components/Molecules/NavLink';
 import Header from '@/components/Organisms/Header';
 
-import SkeletonMilestoneTable from '@/components/Skeleton/MilestoneTable';
-
 import { BUTTON_PROPS, NAV_DATA } from '@/pages/Private/Milestones/constants';
-
-import useFetchMilestone from '@/hooks/useFetchMilestone';
-
-const MilestoneTable = lazy(() => import('@/components/Organisms/MilestoneTable'));
+import { FallBackMilestoneTable } from '@/components/Organisms/MilestoneTable';
 
 const NavContainer = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'space-between' })};
@@ -24,8 +19,6 @@ const NavContainer = styled.div`
 const Milestones = () => {
   const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
   const [isOpenAddEdit, setIsOpenAddEdit] = useState(false);
-
-  const { milestoneData } = useFetchMilestone();
 
   const openAddEdit = () => {
     setIsOpenAddEdit((state) => !state);
@@ -39,9 +32,7 @@ const Milestones = () => {
         <Button {...(!isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
       </NavContainer>
       {isOpenAddEdit && <EditMilestone editMode="ADD" setOpenState={setIsOpenAddEdit} />}
-      <Suspense fallback={<SkeletonMilestoneTable />}>
-        <MilestoneTable milestoneData={milestoneData!} />
-      </Suspense>
+      <FallBackMilestoneTable />
     </div>
   );
 };

--- a/src/pages/Private/Milestones/index.tsx
+++ b/src/pages/Private/Milestones/index.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { useRecoilValue } from 'recoil';
+import { LoginUserInfoState } from '@/stores/loginUserInfo';
+
+import styled from 'styled-components';
+import Button from '@/components/Atoms/Button';
+import NavLink from '@/components/Molecules/NavLink';
+import Header from '@/components/Organisms/Header';
+
+import { BUTTON_PROPS, NAV_DATA } from '@/pages/Private/Milestones/constants';
+
+const NavContainer = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'space-between' })};
+  margin-bottom: 24px;
+`;
+
+const Milestones = () => {
+  const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
+  const [isOpenAddEdit, setIsOpenAddEdit] = useState(true);
+
+  const openAddEdit = () => {
+    setIsOpenAddEdit((state) => !state);
+  };
+
+  return (
+    <div>
+      <Header user={LoginUserInfoStateValue} />
+      <NavContainer>
+        <NavLink navData={NAV_DATA} navLinkStyle="LINE" />
+        <Button {...(isOpenAddEdit ? BUTTON_PROPS.ADD : BUTTON_PROPS.CLOSE)} handleOnClick={openAddEdit} />
+      </NavContainer>
+    </div>
+  );
+};
+
+export default Milestones;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,5 +7,6 @@ import OAuthSignUp from '@/pages/Public/SignUp-OAuth';
 import CommonSignUp from '@/pages/Public/SignUp-Common';
 
 import Issues from '@/pages/Private/Issues';
+import Milestones from '@/pages/Private/Milestones';
 
-export { Home, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues };
+export { Home, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues, Milestones };

--- a/src/router/PrivateRouter.tsx
+++ b/src/router/PrivateRouter.tsx
@@ -1,11 +1,12 @@
 import { Route, Routes } from 'react-router-dom';
-import { Home, NotFound, Issues } from '@/pages';
+import { Home, NotFound, Issues, Milestones } from '@/pages';
 
 const PrivateRouter = () => (
   <Routes>
     <Route path="/" element={<Home />}>
       <Route index element={<Issues />} />
       <Route path="/issues" element={<Issues />} />
+      <Route path="/milestone" element={<Milestones />} />
     </Route>
     <Route path="*" element={<NotFound />} />
   </Routes>

--- a/src/stores/milestone.ts
+++ b/src/stores/milestone.ts
@@ -1,0 +1,9 @@
+import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
+import { atom } from 'recoil';
+
+const InitMilestone: MilestoneItemTypes = { id: 0, title: '', description: '', dueDate: '', closed: false };
+
+export const ClickMilestoneState = atom<MilestoneItemTypes>({
+  key: 'ClickMilestoneState',
+  default: InitMilestone,
+});

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,5 +1,5 @@
 export const COLORS = {
-  TITLE_ACVITE: '#14142B',
+  TITLE_ACTIVE: '#14142B',
   BODY: '#4E4B66',
   LABEL: '#6E7191',
   PLACEHOLDER: '#A0A3BD',

--- a/src/test/MilestonePage.test.tsx
+++ b/src/test/MilestonePage.test.tsx
@@ -1,0 +1,118 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { render } from '@/test/utils';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { composeStories } from '@storybook/testing-react';
+import { act } from 'react-dom/test-utils';
+
+import * as MilestonesPageStories from '@/pages/Private/Milestones/MilestonesPage.stories';
+
+const { Initial } = composeStories(MilestonesPageStories);
+
+describe('마일스톤 페이지 테스트', () => {
+  beforeEach(() => {
+    Object.defineProperty(document, 'cookie', {
+      writable: true,
+      value: 'refresh-token',
+    });
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const user = userEvent.setup({ delay: null });
+
+  it('마일스톤 페이지를 조회한다.', async () => {
+    console.log(document.cookie);
+    const { container } = render(<Initial />);
+    await waitFor(() => expect(container).toHaveTextContent('열린 마일스톤'));
+    await waitFor(() => expect(container).toHaveTextContent('닫힌 마일스톤'));
+  });
+
+  it(`제목이 '새로운 마일스톤'인 마일스톤을 추가한다.`, async () => {
+    jest.useFakeTimers();
+    render(<Initial />);
+
+    const addMilestoneButton = screen.getByRole('button', {
+      name: /추가/i,
+    }) as HTMLButtonElement;
+    await user.click(addMilestoneButton);
+
+    const titleInput = screen.getByPlaceholderText('마일스톤 이름') as HTMLInputElement;
+    await user.type(titleInput, '새로운 마일스톤');
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(titleInput).toHaveValue('새로운 마일스톤');
+
+    const saveMilestoneButton = screen.getByRole('button', {
+      name: /완료/i,
+    }) as HTMLButtonElement;
+    expect(saveMilestoneButton).not.toBeDisabled();
+    await user.click(saveMilestoneButton);
+
+    await waitFor(() => {
+      const target = screen.getByText('새로운 마일스톤');
+      expect(target).toBeInTheDocument();
+    });
+  });
+
+  it(`마일스톤의 제목을 '마일스톤 1'에서 '마일스톤 123'으로 수정한다.`, async () => {
+    jest.useFakeTimers();
+    render(<Initial />);
+
+    const modifyMilestoneButton = screen.getAllByText('편집')[0];
+    await user.click(modifyMilestoneButton);
+
+    const titleInput = screen.getByPlaceholderText('마일스톤 이름');
+    await user.type(titleInput, '23');
+    expect(titleInput).toHaveValue('마일스톤 123');
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    const saveMilestoneButton = screen.getByRole('button', {
+      name: /완료/i,
+    }) as HTMLButtonElement;
+    expect(saveMilestoneButton).not.toBeDisabled();
+    await user.click(saveMilestoneButton);
+
+    await waitFor(() => {
+      expect(saveMilestoneButton).not.toBeDisabled();
+      const target = screen.getByText('마일스톤 123');
+      expect(target).toBeInTheDocument();
+    });
+  });
+
+  it(`열린 상태인 '마일스톤 123'을 닫는다.`, async () => {
+    render(<Initial />);
+    const target = await screen.findByText('마일스톤 123');
+    expect(target).toBeInTheDocument();
+
+    const closeMilestoneButton = screen.getAllByText('닫기')[0] as HTMLButtonElement;
+    await user.click(closeMilestoneButton);
+
+    await waitForElementToBeRemoved(target);
+  });
+
+  it(`제목이 '마일스톤 3'인 마일스톤을 삭제한다.`, async () => {
+    render(<Initial />);
+
+    const target = await screen.findByText('마일스톤 3');
+    expect(target).toBeInTheDocument();
+
+    const deleteMilestoneButton = screen.getAllByText('삭제')[0] as HTMLButtonElement;
+    await user.click(deleteMilestoneButton);
+
+    await waitFor(() => {
+      const modalDeleteButton = screen.getByRole('button', {
+        name: /예/i,
+      }) as HTMLButtonElement;
+      screen.debug();
+      user.click(modalDeleteButton);
+    });
+
+    await waitForElementToBeRemoved(target);
+  });
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import THEME from '@/styles/theme';
+
+import { server } from '@/mocks/server';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
+
+const AllTheProviders = ({ children }: { children: JSX.Element }) => {
+  const modalRoot = document.createElement('div');
+  modalRoot.setAttribute('id', 'modal-root');
+  document.body.append(modalRoot);
+
+  return (
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={THEME}>
+          <MemoryRouter initialEntries={['/']}>{children}</MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    </RecoilRoot>
+  );
+};
+
+const mockStoryHandlers = (story: JSX.Element) => server.use(...(story.type.parameters?.msw?.handlers || []));
+
+const customRender = (ui: JSX.Element, options?: any) => {
+  mockStoryHandlers(ui);
+  return render(ui, { wrapper: AllTheProviders, ...options });
+};
+
+export * from '@testing-library/react';
+
+export { customRender as render };


### PR DESCRIPTION
## Description
- #14 
- 마일스톤을 조회, 추가, 수정, 상태 변경, 삭제할 수 있다.
    - 마일스톤 조회시 suspense를 사용하여 로딩시 skeleton UI를 보여준다.
    - 마일스톤 조회 실패시 ErrorBoundary를 사용하여 refetch를 하는 기능을 추가했다.
    - 마일스톤 기능에 대한 stories와 test를 작성했다.

- 추가된 Components
   - **Atoms**: ProgressBar
   - **Molecules**: EditMilestone, MilestoneItem(+EmptyItem)
   - **Organisms**: MilestoneTable(+ErrorMilestoneTable)
   - **Modal**: DeleteMilestone
   - **Skeleton**: MilestoneTable
   - **Page**: Milestones

## Commits
커밋로그 참조

### 결과

#### 실행1 - 마일스톤, 조회, 추가, 수정, 삭제
![화면 기록 2022-09-02 오후 2 37 46](https://user-images.githubusercontent.com/85747667/188066779-7bebd926-0b53-46a8-8019-f3b6cf66a4cb.gif)

#### 실행2 - api 요청 실패시
![화면 기록 2022-09-02 오후 2 39 18](https://user-images.githubusercontent.com/85747667/188066924-58f0bbb3-bd06-4888-ad5e-83ac572eb624.gif)

#### 테스트 결과
<img width="763" alt="스크린샷 2022-09-02 오후 2 43 55" src="https://user-images.githubusercontent.com/85747667/188066977-beec0651-763d-43eb-b48c-8454da4932fe.png">

