### PR TITLE
💄 이슈 생성 페이지 관련 컴포넌트 (TextArea, Sidebar 등) 및 페이지 UI 구현

### DIFF
--- a/src/api/login_logout.ts
+++ b/src/api/login_logout.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError } from 'axios';
 import { OAuthResponse } from '@/api/signUp';
+import { UserTypes } from '@/components/Molecules/Dropdown/types';
 
 export const silentRefresh = async () => {
   try {
@@ -47,6 +48,16 @@ export const logout = async () => {
     await axios.head('api/members/signout');
     axios.defaults.headers.common.Authorization = '';
     localStorage.removeItem('Authentication');
+  } catch (error) {
+    const err = error as AxiosError;
+    throw err;
+  }
+};
+
+export const getMemberData = async () => {
+  try {
+    const { data } = await axios.get<UserTypes[]>('api/members');
+    return data;
   } catch (error) {
     const err = error as AxiosError;
     throw err;

--- a/src/components/Atoms/Input/index.styles.ts
+++ b/src/components/Atoms/Input/index.styles.ts
@@ -15,7 +15,8 @@ export const Form = styled.form<FormStyleTypes>`
   }
 
   label {
-    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL}
+    color: ${({ theme }) => theme.COLORS.LABEL};
+    ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL}
   }
 
   ${({ inputSize }) => {
@@ -49,6 +50,10 @@ export const Form = styled.form<FormStyleTypes>`
       color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
       background: ${({ theme }) => theme.COLORS.OFF_WHITE};
       border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+
+      label {
+        color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+      }
     `}
   
   &:disabled {

--- a/src/components/Atoms/ProgressBar/index.styles.ts
+++ b/src/components/Atoms/ProgressBar/index.styles.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 export const PrograssBar = styled.progress`
   display: block;
   width: 244px;
+  height: 10px;
   margin-bottom: 8px;
   appearance: none;
 

--- a/src/components/Atoms/ProgressBar/index.styles.ts
+++ b/src/components/Atoms/ProgressBar/index.styles.ts
@@ -18,10 +18,16 @@ export const PrograssBar = styled.progress`
 `;
 
 export const PrograssState = styled.div`
-  display: grid;
-  width: 244px;
-  grid-template-columns: 45% 25% 25%;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
   gap: 8px;
+
+  div {
+    span + span {
+      margin-left: 8px;
+    }
+  }
 
   span {
     ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL};

--- a/src/components/Atoms/ProgressBar/index.tsx
+++ b/src/components/Atoms/ProgressBar/index.tsx
@@ -18,8 +18,10 @@ const PrograssBar = ({ open, close, showState, title }: PrograssBarTypes) => {
       {showState && (
         <S.PrograssState>
           <span>{progressValue}%</span>
-          <span>열린 이슈 {open}</span>
-          <span>닫힌 이슈 {close}</span>
+          <div>
+            <span>열린 이슈 {open}</span>
+            <span>닫힌 이슈 {close}</span>
+          </div>
         </S.PrograssState>
       )}
     </>

--- a/src/components/Atoms/TextArea/TextArea.stories.tsx
+++ b/src/components/Atoms/TextArea/TextArea.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { useState } from 'react';
+import TextArea from '.';
+
+export default {
+  title: 'Atoms/TextArea',
+  component: TextArea,
+} as ComponentMeta<typeof TextArea>;
+
+const Template: ComponentStory<typeof TextArea> = () => {
+  const [areaValue, setAreaValue] = useState<string>('');
+
+  return (
+    <div>
+      <TextArea textAreaValue={areaValue} setAreaValue={setAreaValue} />
+    </div>
+  );
+};
+
+export const Initial = Template.bind({});

--- a/src/components/Atoms/TextArea/index.styles.ts
+++ b/src/components/Atoms/TextArea/index.styles.ts
@@ -1,0 +1,72 @@
+import styled, { css } from 'styled-components';
+
+export const TextAreaContainer = styled.div<{ isActive: boolean }>`
+  ${({ theme }) => theme.MIXIN.FLEX({ direction: 'column', align: 'flex-start', justify: 'center' })};
+  max-width: 880px;
+  border-radius: 16px;
+
+  ${({ isActive }) =>
+    isActive
+      ? css`
+          border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
+          background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+        `
+      : css`
+          border: 1px solid ${({ theme }) => theme.COLORS.INPUT_BACKGROUND};
+          background: ${({ theme }) => theme.COLORS.INPUT_BACKGROUND};
+        `}
+`;
+
+export const TextAreaLabel = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'space-between' })};
+  padding: 16px 24px 0 24px;
+  width: 100%;
+  color: ${({ theme }) => theme.COLORS.LABEL};
+  ${({ theme }) => theme.FONTSTYLES.TEXT_XSMALL}
+`;
+
+export const TextArea = styled.textarea`
+  width: 100%;
+  height: 290px;
+  padding: 16px 24px;
+  border: none;
+  background: none;
+  resize: none;
+  ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL}
+
+  &::placeholder {
+    color: ${({ theme }) => theme.COLORS.PLACEHOLDER};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+export const TextAreaAddFile = styled.div<{ isActive: boolean }>`
+  border-top:  ${({ isActive }) =>
+    isActive
+      ? css`1px dashed ${({ theme }) => theme.COLORS.TITLE_ACTIVE};`
+      : css`1px dashed ${({ theme }) => theme.COLORS.LINE};`}
+  width: 100%;
+  padding: 16px 24px;
+
+  label {
+    ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'flex-start' })};
+  }
+
+  input {
+    display: none;
+  }
+
+  svg {
+    cursor: pointer;
+  }
+
+  span {
+    margin-left: 10px;
+    ${({ theme }) => theme.FONTSTYLES.LINK_XSMALL}
+    color: ${({ theme }) => theme.COLORS.LABEL};
+    cursor: pointer;
+  }
+`;

--- a/src/components/Atoms/TextArea/index.tsx
+++ b/src/components/Atoms/TextArea/index.tsx
@@ -49,7 +49,7 @@ const TextArea = ({ textAreaValue, setAreaValue }: TextAreaTypes) => {
         ref={textAreaRef}
         onChange={handleTextareaChange}
       >
-        {textAreaValue}
+        {textAreaValue || undefined}
       </S.TextArea>
       <S.TextAreaAddFile className="textArea_addFile" isActive={isActive}>
         <label htmlFor="textArea_addFile">

--- a/src/components/Atoms/TextArea/index.tsx
+++ b/src/components/Atoms/TextArea/index.tsx
@@ -1,0 +1,65 @@
+import React, { useRef, useState } from 'react';
+
+import * as S from '@/components/Atoms/TextArea/index.styles';
+import Icon from '@/components/Atoms/Icon';
+import { COLORS } from '@/styles/theme';
+
+interface TextAreaTypes {
+  textAreaValue: string;
+  setAreaValue: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const DEFAULT_TEXTAREA_MAX_LENGTH = 1000;
+const PLACEHOLDER = '코멘트를 입력하세요';
+
+const TextArea = ({ textAreaValue, setAreaValue }: TextAreaTypes) => {
+  const [isActive, setIsActive] = useState<boolean>(false);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+  const countText = `띄어쓰기 포함 ${textAreaValue ? textAreaValue.length : 0}자`;
+
+  const handleFormClick = () => {
+    textAreaRef.current?.focus();
+    setIsActive(true);
+  };
+
+  const handleTextareaChange = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    const { value } = event.currentTarget;
+    if (!value) return setAreaValue('');
+    if (Number(value) >= DEFAULT_TEXTAREA_MAX_LENGTH) {
+      // eslint-disable-next-line no-param-reassign
+      event.currentTarget.value = value.slice(0, DEFAULT_TEXTAREA_MAX_LENGTH);
+    }
+    return setAreaValue(value);
+  };
+
+  return (
+    <S.TextAreaContainer isActive={isActive} onClick={handleFormClick} onBlur={() => setIsActive(false)}>
+      {textAreaValue && (
+        <S.TextAreaLabel>
+          <label htmlFor="textArea">{PLACEHOLDER}</label>
+          <span>{countText}</span>
+        </S.TextAreaLabel>
+      )}
+      <S.TextArea
+        name=""
+        id="textArea"
+        maxLength={DEFAULT_TEXTAREA_MAX_LENGTH}
+        placeholder={PLACEHOLDER}
+        ref={textAreaRef}
+        onChange={handleTextareaChange}
+      >
+        {textAreaValue}
+      </S.TextArea>
+      <S.TextAreaAddFile className="textArea_addFile" isActive={isActive}>
+        <label htmlFor="textArea_addFile">
+          <input id="textArea_addFile" type="file" />
+          <Icon icon="PaperClip" stroke={COLORS.LABEL} />
+          <span>파일 첨부하기</span>
+        </label>
+      </S.TextAreaAddFile>
+    </S.TextAreaContainer>
+  );
+};
+
+export default TextArea;

--- a/src/components/Atoms/UserImage/index.tsx
+++ b/src/components/Atoms/UserImage/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import * as S from '@/components/Atoms/UserImage/index.styles';
 
 export interface UserImageTypes {
@@ -7,11 +8,17 @@ export interface UserImageTypes {
   imgSize?: 'MEDIUM' | 'SMALL';
 }
 
+const DEFAULT_IMG = 'https://avatars.githubusercontent.com/u/92701121?v=4';
+
 const UserImage = ({ imgSize = 'SMALL', ...props }: UserImageTypes) => {
   const { id, nickname, profileImage } = props;
   const imgAlt = `${nickname}의 프로필 사진`;
 
-  return <S.Img src={profileImage} alt={imgAlt} imgSize={imgSize} />;
+  const handleOnErrorImg = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    e.currentTarget.src = DEFAULT_IMG;
+  };
+
+  return <S.Img src={profileImage} alt={imgAlt} imgSize={imgSize} onError={handleOnErrorImg} />;
 };
 
 export default UserImage;

--- a/src/components/Molecules/Dropdown/Indicator/index.stories.tsx
+++ b/src/components/Molecules/Dropdown/Indicator/index.stories.tsx
@@ -20,3 +20,10 @@ Filterbar.args = {
   indicatorLabel: '필터',
   isActive: false,
 };
+
+export const Sidebar = Template.bind({});
+Sidebar.args = {
+  indicatorStyle: 'SIDEBAR',
+  indicatorLabel: '사이드 바',
+  isActive: false,
+};

--- a/src/components/Molecules/Dropdown/Indicator/index.styles.ts
+++ b/src/components/Molecules/Dropdown/Indicator/index.styles.ts
@@ -45,6 +45,14 @@ export const Indicator = styled.summary<StyledDropdownIndicatorTypes>`
       }
     `};
 
+  ${({ indicatorStyle }) =>
+    indicatorStyle === 'SIDEBAR' &&
+    css`
+      span {
+        width: 224px;
+      }
+    `};
+
   ${({ indicatorStyle, isActive }) =>
     indicatorStyle &&
     isActive &&

--- a/src/components/Molecules/Dropdown/Indicator/index.tsx
+++ b/src/components/Molecules/Dropdown/Indicator/index.tsx
@@ -8,7 +8,7 @@ const DropdownIndicator = ({ ...props }: DropdownIndicatorTypes) => {
   return (
     <S.Indicator role="button" indicatorStyle={indicatorStyle} isActive={isActive}>
       <span>{indicatorLabel}</span>
-      <Icon icon="Caret" stroke={COLORS.LABEL} />
+      <Icon icon={indicatorStyle === 'SIDEBAR' ? 'Plus' : 'Caret'} stroke={COLORS.LABEL} />
     </S.Indicator>
   );
 };

--- a/src/components/Molecules/Dropdown/Panel/index.tsx
+++ b/src/components/Molecules/Dropdown/Panel/index.tsx
@@ -1,6 +1,8 @@
 import * as S from '@/components/Molecules/Dropdown/Panel/index.styles';
 import PanelPreviewLabel from '@/components/Molecules/Dropdown/Panel/Label';
-import { DropdownPanelsTypes, IssueTypes, LabelTypes, UserTypes } from '@/components/Molecules/Dropdown/types';
+import { DropdownPanelsTypes, IssueTypes, UserTypes } from '@/components/Molecules/Dropdown/types';
+import { LabelTypes } from '@/stores/labelList';
+import { MilestoneItemTypes } from '../../MilestoneItem';
 
 const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
   const { panelTitle, panelType, panelList, unusedOption } = props;
@@ -19,19 +21,20 @@ const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
         )}
         {panelList.map(({ ...listProps }) => {
           const { id: issueId, title: issueTitle, dataId } = listProps as IssueTypes;
-          const { id: labelId, title: labelTitle, backgroundColor } = listProps as LabelTypes;
-          const { id: userImgId, loginId, profileImageUrl } = listProps as UserTypes;
+          const { id: labelId, title: labelTitle, backgroundColorCode } = listProps as LabelTypes;
+          const { id: userImgId, nickname, profileImageUrl } = listProps as UserTypes;
+          const { id: milestoneId, title: milestoneTitle } = listProps as MilestoneItemTypes;
 
-          const ITEM_KEY = `${panelTitle}-${issueId || labelId || userImgId}`;
-          const INPUT_NAME = issueTitle || labelTitle || loginId;
-          const DATASET_ID = dataId || labelTitle || loginId;
+          const ITEM_KEY = `${panelTitle}-${issueId || labelId || milestoneId || userImgId}`;
+          const INPUT_NAME = issueTitle || labelTitle || milestoneTitle || nickname;
+          const DATASET_ID = dataId || labelTitle || milestoneTitle || nickname;
 
           return (
             <S.PanelItem key={ITEM_KEY}>
               <input id={ITEM_KEY} type={panelType} name={panelTitle} data-id={DATASET_ID} />
               <label htmlFor={ITEM_KEY}>
-                {backgroundColor && <PanelPreviewLabel backgroundColor={backgroundColor} />}
-                {profileImageUrl && <PanelPreviewLabel profileImageUrl={profileImageUrl} loginId={loginId} />}
+                {backgroundColorCode && <PanelPreviewLabel backgroundColor={backgroundColorCode} />}
+                {profileImageUrl && <PanelPreviewLabel profileImageUrl={profileImageUrl} loginId={nickname} />}
                 <span>{INPUT_NAME}</span>
               </label>
             </S.PanelItem>

--- a/src/components/Molecules/Dropdown/Panel/index.tsx
+++ b/src/components/Molecules/Dropdown/Panel/index.tsx
@@ -1,11 +1,14 @@
+import React from 'react';
+
 import * as S from '@/components/Molecules/Dropdown/Panel/index.styles';
 import PanelPreviewLabel from '@/components/Molecules/Dropdown/Panel/Label';
+
 import { DropdownPanelsTypes, IssueTypes, UserTypes } from '@/components/Molecules/Dropdown/types';
 import { LabelTypes } from '@/stores/labelList';
-import { MilestoneItemTypes } from '../../MilestoneItem';
+import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
 
 const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
-  const { panelId, panelTitle, panelType, panelList, unusedOption } = props;
+  const { panelId, panelTitle, panelType, panelList, unusedOption, handleOnClick, isChecked } = props;
 
   return (
     <S.Panel>
@@ -22,16 +25,29 @@ const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
         {panelList.map(({ ...listProps }) => {
           const { id: issueId, title: issueTitle, dataId } = listProps as IssueTypes;
           const { id: labelId, title: labelTitle, backgroundColorCode } = listProps as LabelTypes;
-          const { id: userImgId, nickname, profileImageUrl } = listProps as UserTypes;
           const { id: milestoneId, title: milestoneTitle } = listProps as MilestoneItemTypes;
+          const { id: userImgId, nickname, profileImageUrl } = listProps as UserTypes;
 
           const ITEM_KEY = `${panelTitle}-${issueId || labelId || milestoneId || userImgId}`;
           const INPUT_NAME = issueTitle || labelTitle || milestoneTitle || nickname;
           const DATASET_ID = dataId || labelTitle || milestoneTitle || nickname;
 
+          const handelOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+            const target = event.target as HTMLInputElement;
+            handleOnClick!(target);
+          };
+
           return (
             <S.PanelItem key={ITEM_KEY}>
-              <input id={ITEM_KEY} type={panelType} name={panelTitle} data-id={DATASET_ID} data-panel={panelId} />
+              <input
+                id={ITEM_KEY}
+                type={panelType}
+                name={panelTitle}
+                data-id={DATASET_ID}
+                data-panel={panelId}
+                checked={isChecked?.(INPUT_NAME) || false}
+                onChange={handelOnChange}
+              />
               <label htmlFor={ITEM_KEY}>
                 {backgroundColorCode && <PanelPreviewLabel backgroundColor={backgroundColorCode} />}
                 {profileImageUrl && <PanelPreviewLabel profileImageUrl={profileImageUrl} loginId={nickname} />}

--- a/src/components/Molecules/Dropdown/Panel/index.tsx
+++ b/src/components/Molecules/Dropdown/Panel/index.tsx
@@ -10,13 +10,25 @@ import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
 const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
   const { panelId, panelTitle, panelType, panelList, unusedOption, handleOnClick, isChecked } = props;
 
+  const handelOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const target = event.target as HTMLInputElement;
+    handleOnClick!(target);
+  };
+
   return (
     <S.Panel>
       <h3>{panelTitle}</h3>
       <ul>
         {unusedOption && (
           <S.PanelItem>
-            <input id={unusedOption.dataId} type={panelType} name={panelTitle} data-id={unusedOption.dataId} />
+            <input
+              id={unusedOption.dataId}
+              type={panelType}
+              name={panelTitle}
+              data-id={unusedOption.dataId}
+              data-panel={panelId}
+              onChange={handelOnChange}
+            />
             <label htmlFor={unusedOption.dataId}>
               <span>{unusedOption.title}</span>
             </label>
@@ -31,11 +43,6 @@ const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
           const ITEM_KEY = `${panelTitle}-${issueId || labelId || milestoneId || userImgId}`;
           const INPUT_NAME = issueTitle || labelTitle || milestoneTitle || nickname;
           const DATASET_ID = dataId || labelTitle || milestoneTitle || nickname;
-
-          const handelOnChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-            const target = event.target as HTMLInputElement;
-            handleOnClick!(target);
-          };
 
           return (
             <S.PanelItem key={ITEM_KEY}>

--- a/src/components/Molecules/Dropdown/Panel/index.tsx
+++ b/src/components/Molecules/Dropdown/Panel/index.tsx
@@ -5,7 +5,7 @@ import { LabelTypes } from '@/stores/labelList';
 import { MilestoneItemTypes } from '../../MilestoneItem';
 
 const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
-  const { panelTitle, panelType, panelList, unusedOption } = props;
+  const { panelId, panelTitle, panelType, panelList, unusedOption } = props;
 
   return (
     <S.Panel>
@@ -31,7 +31,7 @@ const DropdownPanel = ({ ...props }: DropdownPanelsTypes) => {
 
           return (
             <S.PanelItem key={ITEM_KEY}>
-              <input id={ITEM_KEY} type={panelType} name={panelTitle} data-id={DATASET_ID} />
+              <input id={ITEM_KEY} type={panelType} name={panelTitle} data-id={DATASET_ID} data-panel={panelId} />
               <label htmlFor={ITEM_KEY}>
                 {backgroundColorCode && <PanelPreviewLabel backgroundColor={backgroundColorCode} />}
                 {profileImageUrl && <PanelPreviewLabel profileImageUrl={profileImageUrl} loginId={nickname} />}

--- a/src/components/Molecules/Dropdown/index.stories.tsx
+++ b/src/components/Molecules/Dropdown/index.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Dropdown from '@/components/Molecules/Dropdown';
-import { UNUSED_OPTIONS, USER_LIST } from '@/components/Molecules/Dropdown/mocks';
-import { ASSIGNEE_DROPDOWN_ARGS } from './mocks';
+import { ASSIGNEE_DROPDOWN_ARGS, MILESTONE_LIST, UNUSED_OPTIONS } from '@/components/Molecules/Dropdown/mocks';
 
 export default {
   title: 'Molecules/Dropdown',
@@ -12,3 +11,13 @@ const Template: ComponentStory<typeof Dropdown> = (args) => <Dropdown {...args} 
 
 export const Initial = Template.bind({});
 Initial.args = ASSIGNEE_DROPDOWN_ARGS;
+
+export const Sidebar = Template.bind({});
+Sidebar.args = {
+  indicatorLabel: '마일스톤',
+  indicatorStyle: 'SIDEBAR',
+  panelTitle: '마일스톤 필터',
+  panelType: 'checkbox',
+  panelList: MILESTONE_LIST,
+  unusedOption: UNUSED_OPTIONS.MILESTONE,
+};

--- a/src/components/Molecules/Dropdown/index.styles.ts
+++ b/src/components/Molecules/Dropdown/index.styles.ts
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-export const Dropdown = styled.details<{ dropdownStyle: 'STANDARD' | 'FILTERBAR' }>`
+export const Dropdown = styled.details<{ dropdownStyle: 'STANDARD' | 'FILTERBAR' | 'SIDEBAR' }>`
   position: relative;
   width: fit-content;
 

--- a/src/components/Molecules/Dropdown/mocks.ts
+++ b/src/components/Molecules/Dropdown/mocks.ts
@@ -102,6 +102,37 @@ export const USER_LIST: UserTypes[] = [
   },
 ];
 
+export const MILESTONE_LIST: MilestoneItemTypes[] = [
+  {
+    id: 0,
+    title: '마일스톤 1',
+    description: null,
+    dueDate: null,
+    closed: false,
+    openIssueCount: 3,
+    closedIssueCount: 7,
+  },
+
+  {
+    id: 1,
+    title: '마일스톤 2',
+    description: '닫힌 마일스톤에 대한 설명',
+    dueDate: null,
+    closed: true,
+    openIssueCount: 16,
+    closedIssueCount: 13,
+  },
+  {
+    id: 2,
+    title: '마일스톤 3',
+    description: '열린 마일스톤에 대한 설명',
+    dueDate: '2022-08-28',
+    closed: false,
+    openIssueCount: 5,
+    closedIssueCount: 5,
+  },
+];
+
 const OPEN_CLOSE_STATE_LIST: IssueTypes[] = [
   {
     id: 0,
@@ -138,7 +169,7 @@ export const MILESTONE_DROPDOWN_ARGS: DropdownTypes = {
   indicatorStyle: 'STANDARD',
   panelTitle: '마일스톤 필터',
   panelType: 'checkbox',
-  panelList: LABEL_LIST,
+  panelList: MILESTONE_LIST,
   unusedOption: UNUSED_OPTIONS.MILESTONE,
 };
 

--- a/src/components/Molecules/Dropdown/mocks.ts
+++ b/src/components/Molecules/Dropdown/mocks.ts
@@ -149,6 +149,7 @@ const OPEN_CLOSE_STATE_LIST: IssueTypes[] = [
 export const ASSIGNEE_DROPDOWN_ARGS: DropdownTypes = {
   indicatorLabel: '담당자',
   indicatorStyle: 'STANDARD',
+  panelId: 'assignee',
   panelTitle: '담당자 필터',
   panelType: 'radio',
   panelList: USER_LIST,
@@ -158,6 +159,7 @@ export const ASSIGNEE_DROPDOWN_ARGS: DropdownTypes = {
 export const LABEL_DROPDOWN_ARGS: DropdownTypes = {
   indicatorLabel: '레이블',
   indicatorStyle: 'STANDARD',
+  panelId: 'label',
   panelTitle: '레이블 필터',
   panelType: 'checkbox',
   panelList: LABEL_LIST,
@@ -167,6 +169,7 @@ export const LABEL_DROPDOWN_ARGS: DropdownTypes = {
 export const MILESTONE_DROPDOWN_ARGS: DropdownTypes = {
   indicatorLabel: '마일스톤',
   indicatorStyle: 'STANDARD',
+  panelId: 'assignee',
   panelTitle: '마일스톤 필터',
   panelType: 'checkbox',
   panelList: MILESTONE_LIST,
@@ -176,6 +179,7 @@ export const MILESTONE_DROPDOWN_ARGS: DropdownTypes = {
 export const AUTHER_DROPDOWN_ARGS: DropdownTypes = {
   indicatorLabel: '작성자',
   indicatorStyle: 'STANDARD',
+  panelId: 'auther',
   panelTitle: '작성자 필터',
   panelType: 'radio',
   panelList: USER_LIST,
@@ -184,6 +188,7 @@ export const AUTHER_DROPDOWN_ARGS: DropdownTypes = {
 export const OPEN_CLOSE_DROPDOWN_ARGS: DropdownTypes = {
   indicatorLabel: '상태 수정',
   indicatorStyle: 'STANDARD',
+  panelId: 'state',
   panelTitle: '상태 변경',
   panelType: 'checkbox',
   panelList: OPEN_CLOSE_STATE_LIST,

--- a/src/components/Molecules/Dropdown/mocks.ts
+++ b/src/components/Molecules/Dropdown/mocks.ts
@@ -1,4 +1,6 @@
-import { IssueTypes, LabelTypes, UserTypes, DropdownTypes } from '@/components/Molecules/Dropdown/types';
+import { IssueTypes, UserTypes, DropdownTypes } from '@/components/Molecules/Dropdown/types';
+import { LabelTypes } from '@/stores/labelList';
+import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
 
 export const UNUSED_OPTIONS = {
   ASSIGNEE: {
@@ -47,44 +49,55 @@ export const LABEL_LIST: LabelTypes[] = [
   {
     id: 0,
     title: 'feature',
-    backgroundColor: '#007AFF',
+    backgroundColorCode: '#007AFF',
+    description: '',
+    textColor: 'BLACK',
   },
   {
     id: 1,
     title: 'Fix',
-    backgroundColor: '#FFD1CF',
+    backgroundColorCode: '#FFD1CF',
+    description: '',
+    textColor: 'BLACK',
   },
   {
     id: 2,
     title: 'refactor',
-    backgroundColor: '#34C759',
+    backgroundColorCode: '#34C759',
+    description: '',
+    textColor: 'BLACK',
   },
 ];
 
 export const USER_LIST: UserTypes[] = [
   {
     id: 0,
-    loginId: '도비',
+    email: 'dobby@gmail.com',
+    nickname: '도비',
     profileImageUrl: 'https://avatars.githubusercontent.com/u/85747667?v=4',
   },
   {
     id: 1,
-    loginId: '도톨',
+    email: 'dotori@gmail.com',
+    nickname: '도토리',
     profileImageUrl: 'https://avatars.githubusercontent.com/u/92701121?v=4',
   },
   {
     id: 2,
-    loginId: '후',
+    email: 'whoo@gmail.com',
+    nickname: '후',
     profileImageUrl: 'https://avatars.githubusercontent.com/u/68011320?v=4',
   },
   {
     id: 3,
-    loginId: '아더',
+    email: 'ader@gmail.com',
+    nickname: '아더',
     profileImageUrl: 'https://avatars.githubusercontent.com/u/29879110?v=4',
   },
   {
     id: 4,
-    loginId: '벡',
+    email: 'beck@gmail.com',
+    nickname: '벡',
     profileImageUrl: 'https://avatars.githubusercontent.com/u/65931336?v=4',
   },
 ];

--- a/src/components/Molecules/Dropdown/types.ts
+++ b/src/components/Molecules/Dropdown/types.ts
@@ -28,6 +28,7 @@ export interface UNUSED_OPTIONS_TYPES {
 }
 
 export interface DropdownPanelsTypes {
+  panelId: 'assignee' | 'label' | 'milestone' | 'issue' | 'auther' | 'state';
   panelTitle: string;
   panelType: 'checkbox' | 'radio';
   panelList: LabelTypes[] | UserTypes[] | IssueTypes[] | MilestoneItemTypes[];

--- a/src/components/Molecules/Dropdown/types.ts
+++ b/src/components/Molecules/Dropdown/types.ts
@@ -33,6 +33,8 @@ export interface DropdownPanelsTypes {
   panelType: 'checkbox' | 'radio';
   panelList: LabelTypes[] | UserTypes[] | IssueTypes[] | MilestoneItemTypes[];
   unusedOption?: UNUSED_OPTIONS_TYPES;
+  handleOnClick?: (target: HTMLInputElement) => void;
+  isChecked?: (title: string) => boolean;
 }
 
 // Panel/Label Types

--- a/src/components/Molecules/Dropdown/types.ts
+++ b/src/components/Molecules/Dropdown/types.ts
@@ -1,3 +1,6 @@
+import { LabelTypes } from '@/stores/labelList';
+import { MilestoneItemTypes } from '../MilestoneItem';
+
 // Indicator Types
 export interface DropdownIndicatorTypes {
   indicatorStyle: 'STANDARD' | 'FILTERBAR';
@@ -6,16 +9,10 @@ export interface DropdownIndicatorTypes {
 }
 
 // Panel Types
-export interface LabelTypes {
-  id: number | string;
-  title: string;
-  backgroundColor: string;
-  titleColor?: 'black' | 'white';
-}
-
 export interface UserTypes {
   id: number | string;
-  loginId: string;
+  email: string;
+  nickname: string;
   profileImageUrl: string;
 }
 
@@ -33,7 +30,7 @@ export interface UNUSED_OPTIONS_TYPES {
 export interface DropdownPanelsTypes {
   panelTitle: string;
   panelType: 'checkbox' | 'radio';
-  panelList: LabelTypes[] | UserTypes[] | IssueTypes[];
+  panelList: LabelTypes[] | UserTypes[] | IssueTypes[] | MilestoneItemTypes[];
   unusedOption?: UNUSED_OPTIONS_TYPES;
 }
 

--- a/src/components/Molecules/Dropdown/types.ts
+++ b/src/components/Molecules/Dropdown/types.ts
@@ -3,7 +3,7 @@ import { MilestoneItemTypes } from '../MilestoneItem';
 
 // Indicator Types
 export interface DropdownIndicatorTypes {
-  indicatorStyle: 'STANDARD' | 'FILTERBAR';
+  indicatorStyle: 'STANDARD' | 'FILTERBAR' | 'SIDEBAR';
   indicatorLabel: string;
   isActive?: boolean;
 }

--- a/src/components/Molecules/FilterBar/mocks.ts
+++ b/src/components/Molecules/FilterBar/mocks.ts
@@ -3,6 +3,7 @@ import { ISSUE_FILTER_LIST } from '@/components/Molecules/Dropdown/mocks';
 
 export const FILTERBAR_INFO: FILTERBAR_INFO_TYPES = {
   DROPDOWN: {
+    panelId: 'issue',
     indicatorLabel: '필터',
     indicatorStyle: 'FILTERBAR',
     panelTitle: '체크박스 필터',

--- a/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
+++ b/src/components/Molecules/MilestoneItem/MilestoneItem.stories.tsx
@@ -14,8 +14,8 @@ Initial.args = {
   id: 0,
   title: '마일스톤 1주차',
   description: '마일스톤 1주차에 대한 설명',
-  closeCount: 3,
-  openCount: 7,
+  openIssueCount: 3,
+  closedIssueCount: 7,
   dueDate: '2022-08-26',
   closed: false,
 };
@@ -31,8 +31,8 @@ OnlyTitle.args = {
   id: 1,
   title: '타이틀만 있는 마일스톤',
   description: null,
-  closeCount: 4,
-  openCount: 18,
+  openIssueCount: 18,
+  closedIssueCount: 5,
   dueDate: null,
   closed: false,
 };

--- a/src/components/Molecules/MilestoneItem/index.tsx
+++ b/src/components/Molecules/MilestoneItem/index.tsx
@@ -19,18 +19,14 @@ export interface MilestoneItemTypes {
   description: string | null;
   dueDate: string | null;
   closed: boolean;
+  openIssueCount: number;
+  closedIssueCount: number;
 }
 
-// 아직 api에 해당 정보가 없어서 타입을 따로 분리해둠
-interface MilestoneItemCountTypes {
-  openCount?: number;
-  closeCount?: number;
-}
-
-const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneItemTypes & MilestoneItemCountTypes) => {
+const MilestoneItem = (props: MilestoneItemTypes) => {
   const { patchMilestoneStateMutate } = useFetchMilestone();
 
-  const { id, title, description, dueDate, closed } = props;
+  const { id, title, description, dueDate, openIssueCount, closedIssueCount, closed } = props;
   const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
   const setIsOpenModalState = useSetRecoilState(ModalState);
   const setClickMilestoneState = useSetRecoilState(ClickMilestoneState);
@@ -64,7 +60,7 @@ const MilestoneItem = ({ openCount = 5, closeCount = 5, ...props }: MilestoneIte
               }}
             />
           </S.MilestoneItemButtons>
-          <PrograssBar open={openCount} close={closeCount} showState />
+          <PrograssBar open={openIssueCount} close={closedIssueCount} showState />
         </div>
       </S.MilestoneItem>
       {isOpenModifyEditer && (

--- a/src/components/Molecules/SideBar/SideBar.stories.tsx
+++ b/src/components/Molecules/SideBar/SideBar.stories.tsx
@@ -3,11 +3,65 @@ import SideBar from '@/components/Molecules/SideBar';
 import { LABEL_LIST, MILESTONE_LIST, USER_LIST } from '@/components/Molecules/Dropdown/mocks';
 import { ContentListTypes, SideBarItemType } from '@/components/Molecules/SideBar/types';
 
+import useFetchMilestone from '@/hooks/useFetchMilestone';
+import useLabelFetch from '@/hooks/useLabelFetch';
+
+import { milestoneHandlers } from '@/mocks/handlers/milestones';
+import { labelHandlers } from '@/mocks/handlers/label';
+
+import { useQuery } from '@tanstack/react-query';
+import { getMemberData } from '@/api/login_logout';
+import { UserTypes } from '@/components/Molecules/Dropdown/types';
+import { authHandlers } from '@/mocks/handlers/auth';
+
 export default {
   title: 'Molecules/SideBar',
   component: SideBar,
 } as ComponentMeta<typeof SideBar>;
 
+const Content = () => {
+  const { milestoneData } = useFetchMilestone();
+  const { useGetLabel } = useLabelFetch();
+  const { data: labelList } = useGetLabel();
+  const { data: userList } = useQuery<UserTypes[]>(['users'], getMemberData);
+
+  const emptyContentList: ContentListTypes = {
+    assignee: [],
+    label: [],
+    milestone: [],
+  };
+
+  const SIDEBAR_PROPS: SideBarItemType[] = [
+    {
+      id: 'assignee',
+      dropdownTitle: '담당자',
+      dropdownListTitle: '담당자 필터',
+      dropdownList: userList!,
+      dropdownType: 'checkbox',
+    },
+    {
+      id: 'label',
+      dropdownTitle: '레이블',
+      dropdownListTitle: '레이블 필터',
+      dropdownList: [...labelList!],
+      dropdownType: 'checkbox',
+    },
+    {
+      id: 'milestone',
+      dropdownTitle: '마일스톤',
+      dropdownListTitle: '마일스톤 필터',
+      dropdownList: [...milestoneData!.openedMilestones],
+      dropdownType: 'radio',
+    },
+  ];
+  return (
+    <div>
+      <SideBar sideBarList={SIDEBAR_PROPS} content={emptyContentList} />
+    </div>
+  );
+};
+
+const Template: ComponentStory<typeof Content> = () => <Content />;
 const MockTemplate: ComponentStory<typeof SideBar> = (args) => <SideBar {...args} />;
 
 const contentList: ContentListTypes = {
@@ -57,6 +111,13 @@ const SIDEBAR_PROPS: SideBarItemType[] = [
     dropdownType: 'radio',
   },
 ];
+
+export const Initial = Template.bind({});
+Initial.parameters = {
+  msw: {
+    handlers: [...milestoneHandlers, ...labelHandlers, ...authHandlers],
+  },
+};
 
 export const Checked = MockTemplate.bind({});
 Checked.args = {

--- a/src/components/Molecules/SideBar/SideBar.stories.tsx
+++ b/src/components/Molecules/SideBar/SideBar.stories.tsx
@@ -1,18 +1,18 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SideBar from '@/components/Molecules/SideBar';
-import { LABEL_LIST, MILESTONE_LIST, USER_LIST } from '@/components/Molecules/Dropdown/mocks';
-import { ContentListTypes, SideBarItemType } from '@/components/Molecules/SideBar/types';
+import { SideBarItemType } from '@/components/Molecules/SideBar/types';
 
+import { useQuery } from '@tanstack/react-query';
 import useFetchMilestone from '@/hooks/useFetchMilestone';
 import useLabelFetch from '@/hooks/useLabelFetch';
+import { getMemberData } from '@/api/login_logout';
+import { UserTypes } from '@/components/Molecules/Dropdown/types';
 
 import { milestoneHandlers } from '@/mocks/handlers/milestones';
 import { labelHandlers } from '@/mocks/handlers/label';
-
-import { useQuery } from '@tanstack/react-query';
-import { getMemberData } from '@/api/login_logout';
-import { UserTypes } from '@/components/Molecules/Dropdown/types';
 import { authHandlers } from '@/mocks/handlers/auth';
+
+import { DEFAULT_CONTENT_LIST, MOCK_CONTENT_LIST, SIDEBAR_PROPS } from '@/components/Molecules/SideBar/mock';
 
 export default {
   title: 'Molecules/SideBar',
@@ -25,13 +25,7 @@ const Content = () => {
   const { data: labelList } = useGetLabel();
   const { data: userList } = useQuery<UserTypes[]>(['users'], getMemberData);
 
-  const emptyContentList: ContentListTypes = {
-    assignee: [],
-    label: [],
-    milestone: [],
-  };
-
-  const SIDEBAR_PROPS: SideBarItemType[] = [
+  const MOCK_SIDEBAR_PROPS: SideBarItemType[] = [
     {
       id: 'assignee',
       dropdownTitle: '담당자',
@@ -56,61 +50,13 @@ const Content = () => {
   ];
   return (
     <div>
-      <SideBar sideBarList={SIDEBAR_PROPS} content={emptyContentList} />
+      <SideBar sideBarList={MOCK_SIDEBAR_PROPS} content={DEFAULT_CONTENT_LIST} />
     </div>
   );
 };
 
 const Template: ComponentStory<typeof Content> = () => <Content />;
 const MockTemplate: ComponentStory<typeof SideBar> = (args) => <SideBar {...args} />;
-
-const contentList: ContentListTypes = {
-  assignee: [],
-  label: [
-    {
-      id: 0,
-      title: 'feature',
-      backgroundColorCode: '#007AFF',
-      description: '',
-      textColor: 'BLACK',
-    },
-  ],
-  milestone: [
-    {
-      id: 0,
-      title: '마일스톤 1',
-      description: null,
-      dueDate: null,
-      closed: false,
-      openIssueCount: 3,
-      closedIssueCount: 7,
-    },
-  ],
-};
-
-const SIDEBAR_PROPS: SideBarItemType[] = [
-  {
-    id: 'assignee',
-    dropdownTitle: '담당자',
-    dropdownListTitle: '담당자 필터',
-    dropdownList: USER_LIST,
-    dropdownType: 'checkbox',
-  },
-  {
-    id: 'label',
-    dropdownTitle: '레이블',
-    dropdownListTitle: '레이블 필터',
-    dropdownList: LABEL_LIST,
-    dropdownType: 'checkbox',
-  },
-  {
-    id: 'milestone',
-    dropdownTitle: '마일스톤',
-    dropdownListTitle: '마일스톤 필터',
-    dropdownList: MILESTONE_LIST,
-    dropdownType: 'radio',
-  },
-];
 
 export const Initial = Template.bind({});
 Initial.parameters = {
@@ -122,5 +68,5 @@ Initial.parameters = {
 export const Checked = MockTemplate.bind({});
 Checked.args = {
   sideBarList: SIDEBAR_PROPS,
-  content: contentList,
+  content: MOCK_CONTENT_LIST,
 };

--- a/src/components/Molecules/SideBar/SideBar.stories.tsx
+++ b/src/components/Molecules/SideBar/SideBar.stories.tsx
@@ -1,0 +1,65 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import SideBar from '@/components/Molecules/SideBar';
+import { LABEL_LIST, MILESTONE_LIST, USER_LIST } from '@/components/Molecules/Dropdown/mocks';
+import { ContentListTypes, SideBarItemType } from '@/components/Molecules/SideBar/types';
+
+export default {
+  title: 'Molecules/SideBar',
+  component: SideBar,
+} as ComponentMeta<typeof SideBar>;
+
+const MockTemplate: ComponentStory<typeof SideBar> = (args) => <SideBar {...args} />;
+
+const contentList: ContentListTypes = {
+  assignee: [],
+  label: [
+    {
+      id: 0,
+      title: 'feature',
+      backgroundColorCode: '#007AFF',
+      description: '',
+      textColor: 'BLACK',
+    },
+  ],
+  milestone: [
+    {
+      id: 0,
+      title: '마일스톤 1',
+      description: null,
+      dueDate: null,
+      closed: false,
+      openIssueCount: 3,
+      closedIssueCount: 7,
+    },
+  ],
+};
+
+const SIDEBAR_PROPS: SideBarItemType[] = [
+  {
+    id: 'assignee',
+    dropdownTitle: '담당자',
+    dropdownListTitle: '담당자 필터',
+    dropdownList: USER_LIST,
+    dropdownType: 'checkbox',
+  },
+  {
+    id: 'label',
+    dropdownTitle: '레이블',
+    dropdownListTitle: '레이블 필터',
+    dropdownList: LABEL_LIST,
+    dropdownType: 'checkbox',
+  },
+  {
+    id: 'milestone',
+    dropdownTitle: '마일스톤',
+    dropdownListTitle: '마일스톤 필터',
+    dropdownList: MILESTONE_LIST,
+    dropdownType: 'radio',
+  },
+];
+
+export const Checked = MockTemplate.bind({});
+Checked.args = {
+  sideBarList: SIDEBAR_PROPS,
+  content: contentList,
+};

--- a/src/components/Molecules/SideBar/SideBar.stories.tsx
+++ b/src/components/Molecules/SideBar/SideBar.stories.tsx
@@ -2,17 +2,13 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SideBar from '@/components/Molecules/SideBar';
 import { SideBarItemType } from '@/components/Molecules/SideBar/types';
 
-import { useQuery } from '@tanstack/react-query';
-import useFetchMilestone from '@/hooks/useFetchMilestone';
-import useLabelFetch from '@/hooks/useLabelFetch';
-import { getMemberData } from '@/api/login_logout';
-import { UserTypes } from '@/components/Molecules/Dropdown/types';
-
 import { milestoneHandlers } from '@/mocks/handlers/milestones';
 import { labelHandlers } from '@/mocks/handlers/label';
 import { authHandlers } from '@/mocks/handlers/auth';
 
 import { DEFAULT_CONTENT_LIST, MOCK_CONTENT_LIST, SIDEBAR_PROPS } from '@/components/Molecules/SideBar/mock';
+
+import useFetchSideBarData from '@/hooks/useFetchSideBarData';
 
 export default {
   title: 'Molecules/SideBar',
@@ -20,31 +16,28 @@ export default {
 } as ComponentMeta<typeof SideBar>;
 
 const Content = () => {
-  const { milestoneData } = useFetchMilestone();
-  const { useGetLabel } = useLabelFetch();
-  const { data: labelList } = useGetLabel();
-  const { data: userList } = useQuery<UserTypes[]>(['users'], getMemberData);
+  const { memberData, labelData, milestoneData } = useFetchSideBarData();
 
   const MOCK_SIDEBAR_PROPS: SideBarItemType[] = [
     {
       id: 'assignee',
       dropdownTitle: '담당자',
       dropdownListTitle: '담당자 필터',
-      dropdownList: userList!,
+      dropdownList: memberData!,
       dropdownType: 'checkbox',
     },
     {
       id: 'label',
       dropdownTitle: '레이블',
       dropdownListTitle: '레이블 필터',
-      dropdownList: [...labelList!],
+      dropdownList: labelData!,
       dropdownType: 'checkbox',
     },
     {
       id: 'milestone',
       dropdownTitle: '마일스톤',
       dropdownListTitle: '마일스톤 필터',
-      dropdownList: [...milestoneData!.openedMilestones],
+      dropdownList: milestoneData!.openedMilestones,
       dropdownType: 'radio',
     },
   ];

--- a/src/components/Molecules/SideBar/SideBarItem/index.tsx
+++ b/src/components/Molecules/SideBar/SideBarItem/index.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable array-callback-return */
+import { Fragment } from 'react';
+import * as S from '@/components/Molecules/SideBar/index.styles';
+import Label from '@/components/Atoms/Label';
+import PrograssBar from '@/components/Atoms/ProgressBar';
+import UserImage from '@/components/Atoms/UserImage';
+import Dropdown from '@/components/Molecules/Dropdown';
+
+import {
+  isAssignTypes,
+  isLabelTypes,
+  isMilestoneTypes,
+  ContentItemTypes,
+  SideBarItemType,
+} from '@/components/Molecules/SideBar/types';
+
+const SideBarItem = ({ ...props }: SideBarItemType & ContentItemTypes) => {
+  const { id, dropdownTitle, dropdownListTitle, dropdownList, dropdownType, content} = props;
+
+  return (
+    <S.SideBarItem key={`sidebar-${id}`} className="sidebar_item">
+      <Dropdown
+        indicatorStyle="SIDEBAR"
+        indicatorLabel={dropdownTitle}
+        panelId={id}
+        panelTitle={dropdownListTitle}
+        panelList={dropdownList}
+        panelType={dropdownType}
+      />
+      <S.SideBarContent isEmpty={!content.length}>
+        {content.map((contentItem) => {
+          if (isAssignTypes(contentItem)) {
+            const { id: userId, nickname, profileImageUrl } = contentItem;
+            return (
+              <S.SideBarAssignee key={nickname}>
+                <UserImage id={Number(userId)} nickname={nickname} profileImage={profileImageUrl} imgSize="MEDIUM" />
+                <span>{nickname}</span>
+              </S.SideBarAssignee>
+            );
+          }
+
+          if (isLabelTypes(contentItem)) {
+            const { title: labelTitle, backgroundColorCode, textColor } = contentItem;
+            return (
+              <li key={labelTitle}>
+                <Label
+                  title={labelTitle}
+                  labelStyle="LIGHT"
+                  textColor={textColor}
+                  backgroundColor={backgroundColorCode}
+                />
+              </li>
+            );
+          }
+
+          if (isMilestoneTypes(contentItem)) {
+            const { title: milestoneTitle, openIssueCount, closedIssueCount } = contentItem;
+            return (
+              <Fragment key={milestoneTitle}>
+                <PrograssBar open={openIssueCount} close={closedIssueCount} title={milestoneTitle} />
+              </Fragment>
+            );
+          }
+        })}
+      </S.SideBarContent>
+    </S.SideBarItem>
+  );
+};
+
+export default SideBarItem;

--- a/src/components/Molecules/SideBar/SideBarItem/index.tsx
+++ b/src/components/Molecules/SideBar/SideBarItem/index.tsx
@@ -14,8 +14,22 @@ import {
   SideBarItemType,
 } from '@/components/Molecules/SideBar/types';
 
+import { LabelTypes } from '@/stores/labelList';
+import { UserTypes } from '@/components/Molecules/Dropdown/types';
+import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
+
 const SideBarItem = ({ ...props }: SideBarItemType & ContentItemTypes) => {
-  const { id, dropdownTitle, dropdownListTitle, dropdownList, dropdownType, content} = props;
+  const { id, dropdownTitle, dropdownListTitle, dropdownList, dropdownType, content, handleOnChange } = props;
+
+  const isChecked = (title: string) => {
+    const contentList: (UserTypes | LabelTypes | MilestoneItemTypes)[] = content;
+    const findContent = contentList.find((el) => {
+      if (isAssignTypes(el)) return el.nickname === title;
+      if (isLabelTypes(el) || isMilestoneTypes(el)) return el.title === title;
+    });
+
+    return !!findContent;
+  };
 
   return (
     <S.SideBarItem key={`sidebar-${id}`} className="sidebar_item">
@@ -26,6 +40,8 @@ const SideBarItem = ({ ...props }: SideBarItemType & ContentItemTypes) => {
         panelTitle={dropdownListTitle}
         panelList={dropdownList}
         panelType={dropdownType}
+        handleOnClick={handleOnChange}
+        isChecked={isChecked}
       />
       <S.SideBarContent isEmpty={!content.length}>
         {content.map((contentItem) => {

--- a/src/components/Molecules/SideBar/SideBarItem/index.tsx
+++ b/src/components/Molecules/SideBar/SideBarItem/index.tsx
@@ -42,6 +42,7 @@ const SideBarItem = ({ ...props }: SideBarItemType & ContentItemTypes) => {
         panelType={dropdownType}
         handleOnClick={handleOnChange}
         isChecked={isChecked}
+        unusedOption={id === 'milestone' ? { dataId: 'none', title: '마일스톤 없음' } : undefined}
       />
       <S.SideBarContent isEmpty={!content.length}>
         {content.map((contentItem) => {

--- a/src/components/Molecules/SideBar/index.styles.ts
+++ b/src/components/Molecules/SideBar/index.styles.ts
@@ -1,0 +1,49 @@
+import styled, { css } from 'styled-components';
+
+export const SideBar = styled.div`
+  width: fit-content;
+  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+
+  .sidebar_item:first-child {
+    border-radius: 16px 16px 0 0;
+  }
+
+  .sidebar_item:last-child {
+    border-bottom: none;
+    border-radius: 0 0 16px 16px;
+  }
+`;
+
+export const SideBarItem = styled.div`
+  padding: 34px 32px;
+  border-bottom: 1px solid ${({ theme }) => theme.COLORS.LINE};
+`;
+
+export const SideBarContent = styled.ul<{ isEmpty: boolean }>`
+  ${({ isEmpty }) =>
+    !isEmpty &&
+    css`
+      margin-top: 18px;
+    `}
+
+  li {
+    margin-bottom: 16px;
+  }
+
+  li:last-child {
+    margin-bottom: 0px;
+  }
+`;
+
+export const SideBarAssignee = styled.li`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  span {
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+    color: ${({ theme }) => theme.COLORS.LABEL};
+  }
+`;

--- a/src/components/Molecules/SideBar/index.tsx
+++ b/src/components/Molecules/SideBar/index.tsx
@@ -1,0 +1,17 @@
+import * as S from '@/components/Molecules/SideBar/index.styles';
+import SideBarItem from '@/components/Molecules/SideBar/SideBarItem';
+import { SideBarTypes } from '@/components/Molecules/SideBar/types';
+
+const SideBar = ({ ...props }: SideBarTypes) => {
+  const { content, sideBarList } = props;
+
+  return (
+    <S.SideBar>
+      {sideBarList.map((item) => (
+        <SideBarItem {...item} key={item.id} content={content[item.id]} />
+      ))}
+    </S.SideBar>
+  );
+};
+
+export default SideBar;

--- a/src/components/Molecules/SideBar/index.tsx
+++ b/src/components/Molecules/SideBar/index.tsx
@@ -24,6 +24,11 @@ const SideBar = ({ ...props }: SideBarTypes) => {
     const { id, panel } = target.dataset;
     const { checked } = target;
 
+    // 마일스톤 없음 클릭시
+    if (id === 'none' && panel === 'milestone' && checked) {
+      return setContentList({ ...contentList, [panel]: [] });
+    }
+
     const sidebarItem = sideBarList.find((el) => el.id === panel);
     const sidebarDropdownList: (UserTypes | LabelTypes | MilestoneItemTypes)[] = sidebarItem!.dropdownList;
 
@@ -41,13 +46,12 @@ const SideBar = ({ ...props }: SideBarTypes) => {
     });
 
     if (checked) {
-      if (contentKey === 'milestone' && isMilestoneTypes(findContent!)) {
+      if (id !== 'none' && contentKey === 'milestone' && isMilestoneTypes(findContent!)) {
+        // 마일스톤 클릭시 하나의 요소만 들어갈 수 있도록 한다.
         return setContentList({ ...contentList, [contentKey]: [findContent] });
       }
-
       return setContentList({ ...contentList, [contentKey]: [...contentList[contentKey], findContent] });
     }
-
     return setContentList({ ...contentList, [contentKey]: [...filterContent] });
   };
 

--- a/src/components/Molecules/SideBar/mock.ts
+++ b/src/components/Molecules/SideBar/mock.ts
@@ -1,0 +1,56 @@
+import { LABEL_LIST, MILESTONE_LIST, USER_LIST } from '../Dropdown/mocks';
+import { ContentListTypes, SideBarItemType } from './types';
+
+export const DEFAULT_CONTENT_LIST: ContentListTypes = {
+  assignee: [],
+  label: [],
+  milestone: [],
+};
+
+export const MOCK_CONTENT_LIST: ContentListTypes = {
+  assignee: [],
+  label: [
+    {
+      id: 0,
+      title: 'feature',
+      backgroundColorCode: '#007AFF',
+      description: '',
+      textColor: 'BLACK',
+    },
+  ],
+  milestone: [
+    {
+      id: 0,
+      title: '마일스톤 1',
+      description: null,
+      dueDate: null,
+      closed: false,
+      openIssueCount: 3,
+      closedIssueCount: 7,
+    },
+  ],
+};
+
+export const SIDEBAR_PROPS: SideBarItemType[] = [
+  {
+    id: 'assignee',
+    dropdownTitle: '담당자',
+    dropdownListTitle: '담당자 필터',
+    dropdownList: USER_LIST,
+    dropdownType: 'checkbox',
+  },
+  {
+    id: 'label',
+    dropdownTitle: '레이블',
+    dropdownListTitle: '레이블 필터',
+    dropdownList: LABEL_LIST,
+    dropdownType: 'checkbox',
+  },
+  {
+    id: 'milestone',
+    dropdownTitle: '마일스톤',
+    dropdownListTitle: '마일스톤 필터',
+    dropdownList: MILESTONE_LIST,
+    dropdownType: 'radio',
+  },
+];

--- a/src/components/Molecules/SideBar/types.ts
+++ b/src/components/Molecules/SideBar/types.ts
@@ -1,0 +1,38 @@
+import { LabelTypes } from '@/stores/labelList';
+import { UserTypes } from '@/components/Molecules/Dropdown/types';
+import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
+
+export interface ContentListTypes {
+  assignee: UserTypes[];
+  label: LabelTypes[];
+  milestone: MilestoneItemTypes[];
+}
+
+export interface ContentItemTypes {
+  content: UserTypes[] | LabelTypes[] | MilestoneItemTypes[];
+  handleOnChange: (target: HTMLInputElement) => void;
+}
+
+export interface SideBarItemType {
+  id: keyof ContentListTypes;
+  dropdownTitle: string;
+  dropdownListTitle: string;
+  dropdownList: UserTypes[] | LabelTypes[] | MilestoneItemTypes[];
+  dropdownType: 'checkbox' | 'radio';
+}
+
+export interface SideBarTypes {
+  sideBarList: SideBarItemType[];
+  content: ContentListTypes;
+}
+
+// Type Guard
+export const isAssignTypes = (props: UserTypes | LabelTypes | MilestoneItemTypes): props is UserTypes =>
+  (props as UserTypes).nickname !== undefined;
+
+export const isLabelTypes = (props: UserTypes | LabelTypes | MilestoneItemTypes): props is LabelTypes =>
+  (props as LabelTypes).backgroundColorCode !== undefined;
+
+export const isMilestoneTypes = (props: UserTypes | LabelTypes | MilestoneItemTypes): props is MilestoneItemTypes =>
+  (props as MilestoneItemTypes).openIssueCount !== undefined &&
+  (props as MilestoneItemTypes).closedIssueCount !== undefined;

--- a/src/components/Molecules/TextAreaEditer/TextAreaEditer.stories.tsx
+++ b/src/components/Molecules/TextAreaEditer/TextAreaEditer.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import TextAreaEditer from '.';
+
+export default {
+  title: 'Molecules/TextAreaEditer',
+  component: TextAreaEditer,
+} as ComponentMeta<typeof TextAreaEditer>;
+
+const Template: ComponentStory<typeof TextAreaEditer> = (args) => <TextAreaEditer {...args} />;
+
+export const Initial = Template.bind({});
+
+export const InnerText = Template.bind({});
+InnerText.args = {
+  textAreaValue: `# 큰 제목
+  본문
+  - 할 일
+      - 세부사항 1
+      - 세부사항 2
+  
+  ## 소제목
+  기타등등
+  
+  ### 이미지
+  ![프사](https://avatars.githubusercontent.com/u/85747667?v=4)
+  `,
+};

--- a/src/components/Molecules/TextAreaEditer/index.styles.ts
+++ b/src/components/Molecules/TextAreaEditer/index.styles.ts
@@ -1,0 +1,58 @@
+import DEFAULT_MARKDOWN from '@/styles/markdown';
+import styled, { css } from 'styled-components';
+
+export const Editer = styled.div`
+  max-width: 900px;
+  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+  background: white;
+`;
+
+export const EditerNavButtons = styled.div<{ editerMode: 'Write' | 'Preview' }>`
+  margin-bottom: -1px;
+  padding: 16px 16px 0 16px;
+  border-radius: 16px 16px 0 0;
+  background: ${({ theme }) => theme.COLORS.BACKGROUND};
+
+  button {
+    border: none;
+    padding: 8px 16px;
+    background: transparent;
+    ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL}
+  }
+
+  .write_button {
+    margin-right: 4px;
+
+    ${({ editerMode }) =>
+      editerMode === 'Write' &&
+      css`
+        border-radius: 4px 4px 0 0;
+        border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+        border-bottom: 1px solid white;
+        background: white;
+      `}
+  }
+
+  .preview_button {
+    ${({ editerMode }) =>
+      editerMode === 'Preview' &&
+      css`
+        border-radius: 4px 4px 0 0;
+        border: 1px solid ${({ theme }) => theme.COLORS.LINE};
+        border-bottom: 1px solid white;
+        background: white;
+      `}
+  }
+`;
+
+export const EditerTextAreaWrapper = styled.div`
+  border-top: 1px solid ${({ theme }) => theme.COLORS.LINE};
+  padding: 8px;
+
+  .markdown {
+    padding: 0 8px;
+    font-size: 100%;
+    ${DEFAULT_MARKDOWN}
+  }
+`;

--- a/src/components/Molecules/TextAreaEditer/index.tsx
+++ b/src/components/Molecules/TextAreaEditer/index.tsx
@@ -5,7 +5,11 @@ import TextArea from '@/components/Atoms/TextArea';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-const TextAreaEditer = ({ textAreaValue }: { textAreaValue: undefined | string }) => {
+interface TextAreaTypes {
+  textAreaValue?: string;
+}
+
+const TextAreaEditer = ({ textAreaValue }: TextAreaTypes) => {
   const [editerMode, setEditerMode] = useState<'Write' | 'Preview'>('Write');
   const [areaValue, setAreaValue] = useState<string>(textAreaValue || '');
 

--- a/src/components/Molecules/TextAreaEditer/index.tsx
+++ b/src/components/Molecules/TextAreaEditer/index.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+
+import * as S from '@/components/Molecules/TextAreaEditer/index.styles';
+import TextArea from '@/components/Atoms/TextArea';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+const TextAreaEditer = ({ textAreaValue }: { textAreaValue: undefined | string }) => {
+  const [editerMode, setEditerMode] = useState<'Write' | 'Preview'>('Write');
+  const [areaValue, setAreaValue] = useState<string>(textAreaValue || '');
+
+  return (
+    <S.Editer>
+      <S.EditerNavButtons editerMode={editerMode}>
+        <button type="button" className="write_button" onClick={() => setEditerMode('Write')}>
+          Write
+        </button>
+        <button type="button" className="preview_button" onClick={() => setEditerMode('Preview')}>
+          Preview
+        </button>
+      </S.EditerNavButtons>
+      <S.EditerTextAreaWrapper>
+        {editerMode === 'Write' && <TextArea textAreaValue={areaValue} setAreaValue={setAreaValue} />}
+        {editerMode === 'Preview' && (
+          <ReactMarkdown className="markdown" remarkPlugins={[remarkGfm]}>
+            {areaValue}
+          </ReactMarkdown>
+        )}
+      </S.EditerTextAreaWrapper>
+    </S.Editer>
+  );
+};
+
+export default TextAreaEditer;

--- a/src/hooks/useFetchSideBarData.ts
+++ b/src/hooks/useFetchSideBarData.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getMemberData } from '@/api/login_logout';
+import { getLabelData } from '@/api/labelList';
+import { getMilestoneData } from '@/api/milestone';
+
+const useFetchSideBarData = () => {
+  const { data: memberData } = useQuery(['members'], getMemberData);
+  const { data: labelData } = useQuery(['labels'], getLabelData);
+  const { data: milestoneData } = useQuery(['milestones'], getMilestoneData);
+
+  return { memberData, labelData, milestoneData };
+};
+
+export default useFetchSideBarData;

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from 'msw';
 import { RedirectAuthTypes, SignInMemberTypes } from '@/api/redirectAuth';
+import { USER_LIST } from '@/components/Molecules/Dropdown/mocks';
 
 const userTable: SignInMemberTypes[] = [
   {
@@ -163,4 +164,12 @@ export const authHandlers = [
 
   // 로그아웃
   rest.head('api/members/signout', (req, res, ctx) => res(ctx.status(200))),
+
+  rest.get('api/members', (req, res, ctx) =>
+    // if (!req.cookies['refresh-token']) {
+    //   return res(ctx.status(400), ctx.json(false));
+    // }
+
+    res(ctx.status(200), ctx.json(USER_LIST)),
+  ),
 ];

--- a/src/mocks/handlers/milestones.ts
+++ b/src/mocks/handlers/milestones.ts
@@ -13,6 +13,8 @@ const milestones: MilestoneListTypes = {
       description: null,
       dueDate: null,
       closed: false,
+      openIssueCount: 3,
+      closedIssueCount: 7,
     },
     {
       id: 2,
@@ -20,6 +22,8 @@ const milestones: MilestoneListTypes = {
       description: '열린 마일스톤에 대한 설명',
       dueDate: '2022-08-28',
       closed: false,
+      openIssueCount: 5,
+      closedIssueCount: 5,
     },
   ],
   closedMilestones: [
@@ -29,6 +33,8 @@ const milestones: MilestoneListTypes = {
       description: '닫힌 마일스톤에 대한 설명',
       dueDate: null,
       closed: true,
+      openIssueCount: 16,
+      closedIssueCount: 13,
     },
   ],
 };
@@ -60,6 +66,8 @@ export const milestoneHandlers = [
       description,
       dueDate,
       closed: false,
+      openIssueCount: 0,
+      closedIssueCount: 0,
     };
 
     milestones.openedMilestones.push(newMilestone);

--- a/src/pages/Private/NewIssue/NewIssue.stories.tsx
+++ b/src/pages/Private/NewIssue/NewIssue.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import NewIssue from '@/pages/Private/NewIssue';
+
+export default {
+  title: 'pages/NewIssue',
+  component: NewIssue,
+} as ComponentMeta<typeof NewIssue>;
+
+const Template: ComponentStory<typeof NewIssue> = () => <NewIssue />;
+
+export const Initial = Template.bind({});

--- a/src/pages/Private/NewIssue/index.styles.ts
+++ b/src/pages/Private/NewIssue/index.styles.ts
@@ -1,0 +1,39 @@
+import styled, { css } from 'styled-components';
+
+export const NewIssue = styled.div`
+  width: 1280px;
+  h1 {
+    ${({ theme }) => theme.FONTSTYLES.DISPLAY_REGULER};
+  }
+`;
+
+export const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  margin: 32px 0;
+  background: ${({ theme }) => theme.COLORS.LINE};
+`;
+
+export const NewIssueEditer = styled.div`
+  width: 100%;
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'space-between' })};
+`;
+
+export const NewIssueForm = styled.div<{ isActive: boolean }>`
+  width: 880px;
+
+  form {
+    position: relative;
+    width: 100%;
+    margin-bottom: 16px;
+    border: ${({ isActive }) =>
+      isActive
+        ? css`1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE}`
+        : css`1px solid ${({ theme }) => theme.COLORS.LINE}`};
+  }
+`;
+
+export const NewIssueButtons = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-end' })};
+  gap: 32px;
+`;

--- a/src/pages/Private/NewIssue/index.tsx
+++ b/src/pages/Private/NewIssue/index.tsx
@@ -1,0 +1,53 @@
+import { useRecoilValue } from 'recoil';
+import { LoginUserInfoState } from '@/stores/loginUserInfo';
+
+import * as S from '@/pages/Private/NewIssue/index.styles';
+import Button from '@/components/Atoms/Button';
+import Input from '@/components/Atoms/Input';
+import UserImage from '@/components/Atoms/UserImage';
+import SideBar from '@/components/Molecules/SideBar';
+import TextAreaEditer from '@/components/Molecules/TextAreaEditer';
+import Header from '@/components/Organisms/Header';
+import { DEFAULT_CONTENT_LIST, SIDEBAR_PROPS } from '@/components/Molecules/SideBar/mock';
+
+import useInput from '@/hooks/useInput';
+
+const NewIssue = () => {
+  const LoginUserInfoStateValue = useRecoilValue(LoginUserInfoState);
+  const { isActive, isTyping, onChangeInput, onClickInput, onBlurInput } = useInput();
+
+  return (
+    <div>
+      <Header user={LoginUserInfoStateValue} />
+      <S.NewIssue>
+        <h1>새로운 이슈 작성</h1>
+        <S.Divider />
+        <S.NewIssueEditer>
+          <UserImage imgSize="MEDIUM" {...LoginUserInfoStateValue} />
+          <S.NewIssueForm isActive={isActive}>
+            <Input
+              inputMaxLength={255}
+              inputPlaceholder="제목"
+              inputSize="MEDIUM"
+              inputType="text"
+              isActive={isActive}
+              isTyping={isTyping}
+              onChange={onChangeInput}
+              onClick={onClickInput}
+              onBlur={onBlurInput}
+            />
+            <TextAreaEditer />
+          </S.NewIssueForm>
+          <SideBar content={DEFAULT_CONTENT_LIST} sideBarList={SIDEBAR_PROPS} />
+        </S.NewIssueEditer>
+        <S.Divider />
+        <S.NewIssueButtons>
+          <Button buttonStyle="NO_BORDER" iconInfo={{ icon: 'XSquare' }} label="작성 취소" size="SMALL" />
+          <Button buttonStyle="STANDARD" label="완료" size="MEDIUM" />
+        </S.NewIssueButtons>
+      </S.NewIssue>
+    </div>
+  );
+};
+
+export default NewIssue;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,14 @@
 import Home from '@/pages/Home';
 import NotFound from '@/pages/NotFound';
 
-import LabelList from '@/pages/Private/LabelList';
-
 import RedirectAuth from '@/pages/Public/RedirectAuth';
 import Login from '@/pages/Public/Login';
 import OAuthSignUp from '@/pages/Public/SignUp-OAuth';
 import CommonSignUp from '@/pages/Public/SignUp-Common';
 
 import Issues from '@/pages/Private/Issues';
+import NewIssue from '@/pages/Private/NewIssue';
+import LabelList from '@/pages/Private/LabelList';
 import Milestones from '@/pages/Private/Milestones';
 
-export { Home, LabelList, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues, Milestones };
+export { Home, LabelList, NotFound, RedirectAuth, Login, OAuthSignUp, CommonSignUp, Issues, NewIssue, Milestones };

--- a/src/router/PrivateRouter.tsx
+++ b/src/router/PrivateRouter.tsx
@@ -1,11 +1,12 @@
 import { Route, Routes } from 'react-router-dom';
-import { Home, NotFound, Issues, LabelList, Milestones } from '@/pages';
+import { Home, NotFound, Issues, LabelList, Milestones, NewIssue } from '@/pages';
 
 const PrivateRouter = () => (
   <Routes>
     <Route path="/" element={<Home />}>
       <Route index element={<Issues />} />
       <Route path="/issues" element={<Issues />} />
+      <Route path="/issues/new" element={<NewIssue />} />
       <Route path="/label" element={<LabelList />} />
       <Route path="/milestone" element={<Milestones />} />
     </Route>

--- a/src/stores/milestone.ts
+++ b/src/stores/milestone.ts
@@ -1,7 +1,15 @@
 import { MilestoneItemTypes } from '@/components/Molecules/MilestoneItem';
 import { atom } from 'recoil';
 
-const InitMilestone: MilestoneItemTypes = { id: 0, title: '', description: '', dueDate: '', closed: false };
+const InitMilestone: MilestoneItemTypes = {
+  id: 0,
+  title: '',
+  description: '',
+  dueDate: '',
+  closed: false,
+  openIssueCount: 0,
+  closedIssueCount: 0,
+};
 
 export const ClickMilestoneState = atom<MilestoneItemTypes>({
   key: 'ClickMilestoneState',

--- a/src/stores/sidebar.ts
+++ b/src/stores/sidebar.ts
@@ -1,0 +1,13 @@
+import { atom } from 'recoil';
+import { ContentListTypes } from '@/components/Molecules/SideBar/types';
+
+const DEFAULT_CONTENT_LIST: ContentListTypes = {
+  assignee: [],
+  label: [],
+  milestone: [],
+};
+
+export const SidebarState = atom({
+  key: 'SidebarState',
+  default: DEFAULT_CONTENT_LIST,
+});

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -1,0 +1,61 @@
+const DEFAULT_MARKDOWN = `
+  font-size: 16px;  
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  em,
+  b,
+  u,
+  p,
+  a,
+  dl,
+  dt,
+  dd,
+  fieldset,
+  form,
+  label,
+  legend,
+  caption,
+  table,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  input {
+    margin: revert;
+    padding: revert;
+    border: revert;
+    font-size: revert;
+    text-decoration: revert;
+  }
+
+  pre,
+  code {
+    font: revert;
+  }
+
+  a {
+    color: blue;
+  }
+
+  menu,
+  ol,
+  ul {
+    margin: revert;
+    padding: revert;
+    list-style: revert;
+  }
+
+  blockquote,
+  q {
+    quotes: revert;
+  }
+`;
+
+export default DEFAULT_MARKDOWN;

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -14,6 +14,12 @@ module.exports = merge(common, {
           options: { compilerOptions: { noEmit: false } },
         },
       },
+      {
+        test: /\.m?js$/,
+        resolve: {
+          fullySpecified: false,
+        },
+      },
     ],
   },
   devServer: {


### PR DESCRIPTION
## Description
- #26 
- `/issues/new/` 페이지 UI 구현
    - 추가된 컴포넌트
        - TextArea
        - TextAreaEditer (마크다운 문법으로 작성한 글 미리보기 가능)
        - Sidebar
- 그 외 수정사항
    - ProgressBar UI 수정
    - Dropdown과 관련된 type 추가 및 수정
    - webpack build 오류에 대한 설정 추가
    - UserImg 컴포넌트 이미지 에러 처리

## Commits

커밋 참고


### 결과

#### TextArea
<img width="594" alt="스크린샷 2022-09-07 오후 3 42 53" src="https://user-images.githubusercontent.com/85747667/188807576-7a081e55-2f9b-468c-acaf-d46649f366bb.png">

#### TextAreaEditer
<img width="596" alt="스크린샷 2022-09-07 오후 3 43 17" src="https://user-images.githubusercontent.com/85747667/188807685-4c4c2116-c9c6-4662-a437-21168fe8feb0.png">

#### Sidebar

<img width="596" alt="스크린샷 2022-09-07 오후 3 43 24" src="https://user-images.githubusercontent.com/85747667/188807730-cb024ebb-3a01-4a2d-b0d4-12ac88b8cb83.png">

