### PR TITLE
🐛 레이블 편집모드 유지 및 URL을 통한 이슈 필터 조회 오류

### DIFF
--- a/src/components/Atoms/ColorCode/index.tsx
+++ b/src/components/Atoms/ColorCode/index.tsx
@@ -1,49 +1,41 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import React from 'react';
-import { useRecoilState } from 'recoil';
 
 import PanelPreviewLabel from '@/components/Molecules/Dropdown/Panel/Label';
 import Button from '@/components/Atoms/Button';
 
-import { LabelState } from '@/stores/label';
-
 import * as S from '@/components/Atoms/ColorCode/index.styled';
+import { LabelTypes } from '@/api/issue/types';
 
 interface ColorCodeTypes {
-  defaultColor?: string;
+  color?: string;
+  setLabelState?: React.Dispatch<React.SetStateAction<LabelTypes>>;
 }
 
 const MAX_COLORCODE_LENGTH = 7;
 const DEFAULT_COLOR = '#EFF0F6';
 const HEAX_COLOR_CODE_REGEX = /(#([a-fA-F0-9]{6}))/g;
 
-const ColorCode = ({ defaultColor = DEFAULT_COLOR }: ColorCodeTypes) => {
-  const [labelState, setLabelState] = useRecoilState(LabelState);
-
+const ColorCode = ({ color = DEFAULT_COLOR, setLabelState }: ColorCodeTypes) => {
   const changeColorCode = () => {
     const r = Math.floor(Math.random() * 127 + 128).toString(16);
     const g = Math.floor(Math.random() * 127 + 128).toString(16);
     const b = Math.floor(Math.random() * 127 + 128).toString(16);
     const newRandomColor = `#${r}${g}${b}`.toUpperCase();
-    setLabelState((prev) => ({ ...prev, label: { ...prev.label, backgroundColorCode: newRandomColor } }));
+    setLabelState?.((prev) => ({ ...prev, backgroundColorCode: newRandomColor }));
   };
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { value } = event.target;
     if (!value.match(HEAX_COLOR_CODE_REGEX)) return;
-    setLabelState((prev) => ({ ...prev, label: { ...prev.label, backgroundColorCode: value } }));
+    setLabelState?.((prev) => ({ ...prev, backgroundColorCode: value }));
   };
 
   return (
     <S.ColorCode>
       <label>배경 색상</label>
-      <input
-        type="text"
-        value={labelState.label.backgroundColorCode || defaultColor}
-        maxLength={MAX_COLORCODE_LENGTH}
-        onChange={handleInputChange}
-      />
-      <PanelPreviewLabel backgroundColor={labelState.label.backgroundColorCode || defaultColor} />
+      <input type="text" value={color} maxLength={MAX_COLORCODE_LENGTH} onChange={handleInputChange} />
+      <PanelPreviewLabel backgroundColor={color} />
       <Button
         buttonStyle="NO_BORDER"
         iconInfo={{

--- a/src/components/Molecules/LabelEditForm/constants.tsx
+++ b/src/components/Molecules/LabelEditForm/constants.tsx
@@ -1,10 +1,11 @@
 import { LabelTypes } from '@/api/issue/types';
 import { COLORS } from '@/styles/theme';
 
-const initLabelState: LabelTypes = {
+export const initLabelState: LabelTypes = {
   id: 0,
   title: '',
   backgroundColorCode: COLORS.INPUT_BACKGROUND,
   description: '',
   textColor: 'BLACK',
 };
+

--- a/src/components/Molecules/LabelEditForm/constants.tsx
+++ b/src/components/Molecules/LabelEditForm/constants.tsx
@@ -1,4 +1,7 @@
 import { LabelTypes } from '@/api/issue/types';
+import { InputTypes } from '@/components/Atoms/Input';
+import { LabelType } from '@/components/Atoms/Label';
+import { RadioTypes } from '@/components/Atoms/Radio';
 import { COLORS } from '@/styles/theme';
 
 export const initLabelState: LabelTypes = {
@@ -9,3 +12,51 @@ export const initLabelState: LabelTypes = {
   textColor: 'BLACK',
 };
 
+const [MAX_TITLE_LENTH, MAX_DESCRIPTION_LENGTH] = [30, 100];
+
+type LabelPropsType = Pick<LabelTypes, 'backgroundColorCode' | 'textColor' | 'title'>;
+type LabelInputPropsType = Pick<InputTypes, 'inputValue' | 'onChange' | 'isTyping'>;
+type TextColorType = Pick<RadioTypes, 'onChange'> & { textColor: string };
+
+interface LABEL_EDIT_FORM_PROPS_Types {
+  LABEL: ({ ...props }: LabelPropsType) => LabelType;
+  LABEL_TITLE: ({ ...props }: LabelInputPropsType) => InputTypes;
+  LABEL_DESCRIPTION: ({ ...props }: LabelInputPropsType) => InputTypes;
+  TEXT_COLOR: ({ ...props }: TextColorType) => RadioTypes;
+}
+
+export const LABEL_EDIT_FORM_PROPS: LABEL_EDIT_FORM_PROPS_Types = {
+  LABEL: ({ backgroundColorCode, textColor, title }) => ({
+    backgroundColorCode: backgroundColorCode || COLORS.INPUT_BACKGROUND,
+    textColor,
+    title: title || '레이블',
+  }),
+  LABEL_TITLE: ({ inputValue, onChange, isTyping }) => ({
+    inputMaxLength: MAX_TITLE_LENTH,
+    inputPlaceholder: '레이블 이름',
+    inputSize: 'SMALL',
+    inputType: 'text',
+    inputValue,
+    onChange,
+    isTyping,
+  }),
+  LABEL_DESCRIPTION: ({ inputValue, onChange, isTyping }) => ({
+    inputMaxLength: MAX_DESCRIPTION_LENGTH,
+    inputPlaceholder: '레이블 이름',
+    inputSize: 'SMALL',
+    inputType: 'text',
+    inputValue,
+    onChange,
+    isTyping,
+  }),
+  TEXT_COLOR: ({ onChange, textColor }) => ({
+    radioData: {
+      title: '텍스트 색상',
+      option: [
+        { id: 1, title: '어두운 색', isChecked: textColor === 'BLACK' },
+        { id: 2, title: '밝은 색', isChecked: textColor === 'WHITE' },
+      ],
+    },
+    onChange,
+  }),
+};

--- a/src/components/Molecules/LabelEditForm/index.tsx
+++ b/src/components/Molecules/LabelEditForm/index.tsx
@@ -17,16 +17,18 @@ import debounce from '@/utils/debounce';
 import * as S from '@/components/Molecules/LabelEditForm/index.styled';
 import { BUTTON_PROPS } from '@/components/Atoms/Button/options';
 
-interface LabelAddFormTypes {
+type LabelEditFormTypes = {
   type: 'ADD' | 'EDIT';
-  onClickCancleButton?: () => void;
-  onClickCompleteButton?: () => void;
-}
+  labelProps: LabelTypes;
+  setIsEditLabel?: React.Dispatch<React.SetStateAction<boolean>>;
+};
 
 const [MAX_TITLE_LENTH, MAX_DESCRIPTION_LENGTH] = [30, 100];
 const DEBOUNCE_DELAY = 200;
 
-const LabelEditForm = ({ type, onClickCancleButton, onClickCompleteButton }: LabelAddFormTypes) => {
+const LabelEditForm = ({ type, labelProps, setIsEditLabel }: LabelEditFormTypes) => {
+  const [labelState, setLabelState] = useState<LabelTypes>(labelProps);
+  const { title, backgroundColorCode, description, textColor } = labelState;
   const timerId = useRef(0);
   const { isTyping: IsTitleTyping, onChangeInput: onChangeTitleInput } = useInput();
   const { isTyping: IsDescriptionTyping, onChangeInput: onChangeDescriptionInput } = useInput();
@@ -37,21 +39,22 @@ const LabelEditForm = ({ type, onClickCancleButton, onClickCompleteButton }: Lab
   const formTitle = type === 'ADD' ? '새로운 레이블 추가' : '레이블 편집';
 
   const handleTitleTyping = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
+    const { value: newTitle } = event.target;
+
     onChangeTitleInput(event);
-    setLabelState((prev) => ({ ...prev, label: { ...prev.label, title: value } }));
+    setLabelState((prev) => ({ ...prev, title: newTitle }));
   };
 
   const handleDescriptionTyping = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { value } = event.target;
+    const { value: newDescription } = event.target;
 
     onChangeDescriptionInput(event);
-    setLabelState((prev) => ({ ...prev, label: { ...prev.label, description: value } }));
+    setLabelState((prev) => ({ ...prev, description: newDescription }));
   };
 
   const hanldeRadioChange = (text: string) => {
     const newTextColor = text === '어두운 색' ? 'BLACK' : 'WHITE';
-    setLabelState((prev) => ({ ...prev, label: { ...prev.label, textColor: newTextColor } }));
+    setLabelState((prev) => ({ ...prev, textColor: newTextColor }));
   };
 
   const isCompleteButtonActivated = labelState.label.title;
@@ -84,7 +87,7 @@ const LabelEditForm = ({ type, onClickCancleButton, onClickCompleteButton }: Lab
             onChange={debounce(timerId, handleDescriptionTyping, DEBOUNCE_DELAY)}
             isTyping={IsDescriptionTyping}
           />
-          <ColorCode />
+          <ColorCode color={labelState.backgroundColorCode} setLabelState={setLabelState} />
           <S.TextColor>
             <label>텍스트 색상</label>
             <Radio

--- a/src/components/Molecules/LabelEditForm/index.tsx
+++ b/src/components/Molecules/LabelEditForm/index.tsx
@@ -77,7 +77,7 @@ const LabelEditForm = ({ type, labelProps, setIsEditLabel }: LabelEditFormTypes)
     setLabelState((prev) => ({ ...prev, textColor: newTextColor }));
   };
 
-  const isCompleteButtonActivated = labelState.label.title;
+  const hasUniqueLabel: boolean = JSON.stringify(labelProps) !== JSON.stringify(labelState) && !!labelState.title;
 
   return (
     <S.LabelEditForm>
@@ -125,7 +125,7 @@ const LabelEditForm = ({ type, labelProps, setIsEditLabel }: LabelEditFormTypes)
       </S.EditField>
       <S.EditButton>
         {type === 'EDIT' && <Button {...BUTTON_PROPS.CLOSE} handleOnClick={handleCancelButtonClick} />}
-        <Button {...BUTTON_PROPS.SAVE} handleOnClick={handleCompleteButtonClick} />
+        <Button {...BUTTON_PROPS.SAVE} handleOnClick={handleCompleteButtonClick} disabled={!hasUniqueLabel} />
       </S.EditButton>
     </S.LabelEditForm>
   );

--- a/src/components/Molecules/LabelEditForm/index.tsx
+++ b/src/components/Molecules/LabelEditForm/index.tsx
@@ -2,7 +2,6 @@
 import React, { useRef, useState } from 'react';
 import { LabelTypes } from '@/api/issue/types';
 
-import { COLORS } from '@/styles/theme';
 import * as S from '@/components/Molecules/LabelEditForm/index.styled';
 
 import Button from '@/components/Atoms/Button';
@@ -15,7 +14,7 @@ import debounce from '@/utils/debounce';
 import useInput from '@/hooks/useInput';
 import useFetchLabel from '@/api/label/useFetchLabel';
 import { BUTTON_PROPS } from '@/components/Atoms/Button/options';
-import { initLabelState } from '@/components/Molecules/LabelEditForm/constants';
+import { initLabelState, LABEL_EDIT_FORM_PROPS } from '@/components/Molecules/LabelEditForm/constants';
 
 type LabelEditFormTypes = {
   type: 'ADD' | 'EDIT';
@@ -23,7 +22,6 @@ type LabelEditFormTypes = {
   setIsEditLabel?: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const [MAX_TITLE_LENTH, MAX_DESCRIPTION_LENGTH] = [30, 100];
 const DEBOUNCE_DELAY = 200;
 
 const LabelEditForm = ({ type, labelProps, setIsEditLabel }: LabelEditFormTypes) => {
@@ -83,43 +81,26 @@ const LabelEditForm = ({ type, labelProps, setIsEditLabel }: LabelEditFormTypes)
     <S.LabelEditForm>
       <S.Title>{formTitle}</S.Title>
       <S.EditField>
-        <Label
-          backgroundColorCode={`${backgroundColorCode || COLORS.INPUT_BACKGROUND}`}
-          textColor={textColor}
-          title={title || '레이블'}
-        />
+        <Label {...LABEL_EDIT_FORM_PROPS.LABEL({ backgroundColorCode, textColor, title })} />
         <S.EditForm>
           <Input
-            inputMaxLength={MAX_TITLE_LENTH}
-            inputPlaceholder="레이블 이름"
-            inputSize="SMALL"
-            inputType="text"
-            inputValue={title}
-            onChange={debounce(timerId, handleTitleTyping, DEBOUNCE_DELAY)}
-            isTyping={IsTitleTyping}
+            {...LABEL_EDIT_FORM_PROPS.LABEL_TITLE({
+              inputValue: title,
+              onChange: debounce(timerId, handleTitleTyping, DEBOUNCE_DELAY),
+              isTyping: IsTitleTyping,
+            })}
           />
           <Input
-            inputMaxLength={MAX_DESCRIPTION_LENGTH}
-            inputPlaceholder="설명(선택)"
-            inputSize="SMALL"
-            inputType="text"
-            inputValue={description}
-            onChange={debounce(timerId, handleDescriptionTyping, DEBOUNCE_DELAY)}
-            isTyping={IsDescriptionTyping}
+            {...LABEL_EDIT_FORM_PROPS.LABEL_DESCRIPTION({
+              inputValue: description,
+              onChange: debounce(timerId, handleDescriptionTyping, DEBOUNCE_DELAY),
+              isTyping: IsDescriptionTyping,
+            })}
           />
           <ColorCode color={labelState.backgroundColorCode} setLabelState={setLabelState} />
           <S.TextColor>
             <label>텍스트 색상</label>
-            <Radio
-              radioData={{
-                title: '텍스트 색상',
-                option: [
-                  { id: 1, title: '어두운 색', isChecked: textColor === 'BLACK' },
-                  { id: 2, title: '밝은 색', isChecked: textColor === 'WHITE' },
-                ],
-              }}
-              onChange={hanldeRadioChange}
-            />
+            <Radio {...LABEL_EDIT_FORM_PROPS.TEXT_COLOR({ onChange: hanldeRadioChange, textColor })} />
           </S.TextColor>
         </S.EditForm>
       </S.EditField>

--- a/src/components/Organisms/LabelTable/LabelItem/index.tsx
+++ b/src/components/Organisms/LabelTable/LabelItem/index.tsx
@@ -29,8 +29,9 @@ const LabelItem = ({ setDeleteLabelId, ...labelProps }: LabelItemTypes) => {
     setIsModal(true);
     setDeleteLabelId(deletedLabelId);
   };
-  const handleLabelClick = (filterdLabelTitle: string) => {
-    navigate(`/issues?q=label%3A"${filterdLabelTitle}"`);
+
+  const handleLabelClick = (filteringLabelTitle: string) => {
+    navigate(`/issues?q=label%3A"${filteringLabelTitle}"`);
   };
 
   return isEditLabel ? (

--- a/src/components/Organisms/LabelTable/LabelItem/index.tsx
+++ b/src/components/Organisms/LabelTable/LabelItem/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { LabelState } from '@/stores/label';
+import { useSetRecoilState } from 'recoil';
 
 import * as S from '@/components/Organisms/LabelTable/LabelItem/index.styled';
 
@@ -12,9 +12,13 @@ import { ModalState } from '@/components/Modal';
 import { LabelTypes } from '@/api/issue/types';
 import { TABLE_ITEM_BUTTON_INFO } from '@/components/Atoms/Button/options';
 
+type LabelItemTypes = LabelTypes & { setDeleteLabelId: React.Dispatch<React.SetStateAction<number>> };
+
+const LabelItem = ({ setDeleteLabelId, ...labelProps }: LabelItemTypes) => {
   const { id, title, backgroundColorCode, description, textColor } = labelProps;
 
   const navigate = useNavigate();
+  const setIsModal = useSetRecoilState<boolean>(ModalState);
   const [isEditLabel, setIsEditLabel] = useState<boolean>(false);
 
   const handleEditButtonClick = () => {
@@ -22,8 +26,8 @@ import { TABLE_ITEM_BUTTON_INFO } from '@/components/Atoms/Button/options';
   };
 
   const handleDeleteButtonClick = (deletedLabelId: number) => {
-    setLabelState((prev) => ({ type: 'DELETE', label: { ...prev.label, id: deletedLabelId } }));
     setIsModal(true);
+    setDeleteLabelId(deletedLabelId);
   };
   const handleLabelClick = (filterdLabelTitle: string) => {
     navigate(`/issues?q=label%3A"${filterdLabelTitle}"`);

--- a/src/components/Organisms/LabelTable/LabelItem/index.tsx
+++ b/src/components/Organisms/LabelTable/LabelItem/index.tsx
@@ -1,4 +1,4 @@
-import { useSetRecoilState } from 'recoil';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { LabelState } from '@/stores/label';
 
@@ -6,19 +6,21 @@ import * as S from '@/components/Organisms/LabelTable/LabelItem/index.styled';
 
 import Button from '@/components/Atoms/Button';
 import Label from '@/components/Atoms/Label';
+import LabelEditForm from '@/components/Molecules/LabelEditForm';
 import { ModalState } from '@/components/Modal';
 
 import { LabelTypes } from '@/api/issue/types';
 import { TABLE_ITEM_BUTTON_INFO } from '@/components/Atoms/Button/options';
 
-const LabelItem = ({ id, title, backgroundColorCode, description, textColor }: LabelTypes) => {
-  const navigate = useNavigate();
-  const setLabelState = useSetRecoilState(LabelState);
-  const setIsModal = useSetRecoilState(ModalState);
+  const { id, title, backgroundColorCode, description, textColor } = labelProps;
 
-  const handleEditButtonClick = (props: LabelTypes) => {
-    setLabelState({ type: 'EDIT', label: props });
+  const navigate = useNavigate();
+  const [isEditLabel, setIsEditLabel] = useState<boolean>(false);
+
+  const handleEditButtonClick = () => {
+    setIsEditLabel(true);
   };
+
   const handleDeleteButtonClick = (deletedLabelId: number) => {
     setLabelState((prev) => ({ type: 'DELETE', label: { ...prev.label, id: deletedLabelId } }));
     setIsModal(true);
@@ -27,7 +29,9 @@ const LabelItem = ({ id, title, backgroundColorCode, description, textColor }: L
     navigate(`/issues?q=label%3A"${filterdLabelTitle}"`);
   };
 
-  return (
+  return isEditLabel ? (
+    <LabelEditForm type="EDIT" labelProps={labelProps} setIsEditLabel={setIsEditLabel} />
+  ) : (
     <S.LabelItem>
       <Label
         title={title}
@@ -37,10 +41,7 @@ const LabelItem = ({ id, title, backgroundColorCode, description, textColor }: L
       />
       <S.Description>{description}</S.Description>
       <S.EditButton>
-        <Button
-          {...TABLE_ITEM_BUTTON_INFO.MODIFY}
-          handleOnClick={() => handleEditButtonClick({ id, title, backgroundColorCode, description, textColor })}
-        />
+        <Button {...TABLE_ITEM_BUTTON_INFO.MODIFY} handleOnClick={handleEditButtonClick} />
         <Button {...TABLE_ITEM_BUTTON_INFO.DELETE} handleOnClick={() => handleDeleteButtonClick(id)} />
       </S.EditButton>
     </S.LabelItem>

--- a/src/components/Organisms/LabelTable/index.tsx
+++ b/src/components/Organisms/LabelTable/index.tsx
@@ -1,43 +1,30 @@
 /* eslint-disable react/prop-types */
-import { Suspense } from 'react';
-import { useRecoilValue, useResetRecoilState } from 'recoil';
+import { Suspense, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import { ErrorBoundary } from 'react-error-boundary';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
+
 import * as S from '@/components/Organisms/LabelTable/index.styled';
 
 import Table from '@/components/Molecules/Table';
-import TableItem from '@/components/Molecules/Table/TableItem';
-import AddLabelField from '@/components/Molecules/LabelEditForm';
-
-import { LabelState } from '@/stores/label';
+import ErrorTable from '@/components/Organisms/ErrorTable';
+import LabelItem from '@/components/Organisms/LabelTable/LabelItem';
+import LabelTableSkeleton from '@/components/Skeleton/LabelTable';
+import DeleteCheck from '@/components/Modal/DeleteCheck';
 
 import useFetchLabel from '@/api/label/useFetchLabel';
 import Modal, { ModalState } from '@/components/Modal';
-import DeleteCheck from '@/components/Modal/DeleteCheck';
-import ErrorTable from '@/components/Organisms/ErrorTable';
-import LabelTableSkeleton from '@/components/Skeleton/LabelTable';
-import LabelItem from '@/components/Organisms/LabelTable/LabelItem';
 
 const LabelTable = () => {
-  const { labelData, replaceLabel, deleteLabel } = useFetchLabel();
+  const { labelData, deleteLabel } = useFetchLabel();
 
   const labelNum = labelData!.length;
 
-  const labelState = useRecoilValue(LabelState);
   const isModal = useRecoilValue(ModalState);
-  const resetLabelState = useResetRecoilState(LabelState);
-
-  const handleCompleteButtonClick = (id: number) => {
-    replaceLabel({ id, replacedLabel: labelState.label });
-    resetLabelState();
-  };
-
-  const handleCancleButtonClick = () => {
-    resetLabelState();
-  };
+  const [deleteLabelId, setDeleteLabelId] = useState<number>(0);
 
   const handleDeleteButtonClick = () => {
-    deleteLabel(labelState.label.id);
+    deleteLabel(deleteLabelId);
   };
 
   return (
@@ -45,7 +32,7 @@ const LabelTable = () => {
       <Table
         header={<span>{`${labelNum}개의 레이블`}</span>}
         item={labelData!.map((props) => (
-          <LabelItem key={props.id} {...props} />
+          <LabelItem key={props.id} setDeleteLabelId={setDeleteLabelId} {...props} />
         ))}
       />
       {isModal && (

--- a/src/components/Organisms/LabelTable/index.tsx
+++ b/src/components/Organisms/LabelTable/index.tsx
@@ -45,17 +45,7 @@ const LabelTable = () => {
       <Table
         header={<span>{`${labelNum}개의 레이블`}</span>}
         item={labelData!.map((props) => (
-          <TableItem key={props.id}>
-            {labelState.type === 'EDIT' && labelState.label.id === props.id ? (
-              <AddLabelField
-                type="EDIT"
-                onClickCancleButton={handleCancleButtonClick}
-                onClickCompleteButton={() => handleCompleteButtonClick(props.id)}
-              />
-            ) : (
-              <LabelItem {...props} />
-            )}
-          </TableItem>
+          <LabelItem key={props.id} {...props} />
         ))}
       />
       {isModal && (

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import useFetchIssue from '@/api/issue/useFetchIssue';
 
@@ -31,6 +31,7 @@ const Issues = () => {
   const pageParams = Number(searchParams.get('page')) || 0;
   const queriesParams = searchParams.get('q');
   const filterState = useRecoilValue(FilterState);
+  const resetFilterState = useResetRecoilState(FilterState);
   const { page, queries } = useRecoilValue(FilterStatsState);
   const setPageState = useSetRecoilState(PageState);
 
@@ -52,6 +53,7 @@ const Issues = () => {
 
   const setURLQueriesToFilterState = () => {
     if (!document.location.search) return;
+    resetFilterState();
 
     setIssueState(queriesParams);
 

--- a/src/pages/Private/Labels/index.tsx
+++ b/src/pages/Private/Labels/index.tsx
@@ -1,5 +1,4 @@
-import { useRecoilState, useResetRecoilState } from 'recoil';
-import useFetchLabel from '@/api/label/useFetchLabel';
+import { useState } from 'react';
 
 import * as S from '@/pages/Private/Labels/index.styled';
 
@@ -8,42 +7,31 @@ import LabelEditForm from '@/components/Molecules/LabelEditForm';
 import NavLink from '@/components/Molecules/NavLink';
 import { FallbackLabelTable } from '@/components/Organisms/LabelTable';
 
+import { initLabelState } from '@/components/Molecules/LabelEditForm/constants';
 import { labelMilestone } from '@/components/Molecules/NavLink/options';
-import { LabelState } from '@/stores/label';
 import { BUTTON_PROPS } from '@/components/Atoms/Button/options';
 
 const Labels = () => {
-  const { addLabel } = useFetchLabel();
-
-  const [labelState, setLabelState] = useRecoilState(LabelState);
-
-  const resetLabelState = useResetRecoilState(LabelState);
+  const [isAddLabel, setIsAddLabel] = useState<boolean>(false);
 
   const handleCloseButtonClick = () => {
-    resetLabelState();
+    setIsAddLabel(false);
   };
 
   const handleAddButtonClick = () => {
-    resetLabelState();
-    setLabelState((prev) => ({ ...prev, type: 'ADD' }));
+    setIsAddLabel(true);
   };
 
-  const handleCompleteButtonClick = () => {
-    addLabel(labelState.label);
-    resetLabelState();
-  };
+  const closeButtonProps = { ...BUTTON_PROPS.CLOSE, handleOnClick: handleCloseButtonClick };
+  const addButtonProps = { ...BUTTON_PROPS.ADD, handleOnClick: handleAddButtonClick };
 
   return (
     <S.Labels>
       <S.SubNav>
         <NavLink navData={labelMilestone()} navLinkStyle="LINE" />
-        {labelState.type === 'ADD' ? (
-          <Button {...BUTTON_PROPS.CLOSE} handleOnClick={handleCloseButtonClick} />
-        ) : (
-          <Button {...BUTTON_PROPS.ADD} handleOnClick={handleAddButtonClick} />
-        )}
+        <Button {...(isAddLabel ? closeButtonProps : addButtonProps)} />
       </S.SubNav>
-      {labelState.type === 'ADD' && <LabelEditForm type="ADD" onClickCompleteButton={handleCompleteButtonClick} />}
+      {isAddLabel && <LabelEditForm type="ADD" labelProps={initLabelState} setIsEditLabel={setIsAddLabel} />}
       <FallbackLabelTable />
     </S.Labels>
   );

--- a/src/stores/label.ts
+++ b/src/stores/label.ts
@@ -1,13 +1,5 @@
 import { LabelTypes } from '@/api/issue/types';
 import { COLORS } from '@/styles/theme';
-import { atom } from 'recoil';
-
-type EditStateType = 'ADD' | 'EDIT' | 'DELETE' | null;
-
-interface LabelStateTypes {
-  type: EditStateType;
-  label: LabelTypes;
-}
 
 const initLabelState: LabelTypes = {
   id: 0,
@@ -16,8 +8,3 @@ const initLabelState: LabelTypes = {
   description: '',
   textColor: 'BLACK',
 };
-
-export const LabelState = atom<LabelStateTypes>({
-  key: 'LabelState',
-  default: { type: null, label: initLabelState },
-});


### PR DESCRIPTION
## Description

- #42 

## Commits

1. 편집폼의 데이터를 전역상태 Recoil로 관리하던 방식에서 LabelEditForm 컴포넌트 내의 독립적인 상태로 관리하도록 수정했다. 
- `Labels` 페이지 컴포넌트는 `레이블 추가폼`을, `LabelItem` 컴포넌트는 `레이블 편집폼`의 렌더링 유무에 관한 상태를 관리한다. 
- `LabelEditForm` 컴포넌트는`레이블 추가폼` 또는 `레이블 편집폼`을 닫거나 레이블 추가, 수정을 할 수 있다. 
- `LabelTable` 컴포넌트는 `DeleteCheck` 모달을 렌더하는 컴포넌트이므로 삭제 레이블에 대한 상태를 관리한다. 
  - `LabelItem`의 prop으로 삭제 모달에 대한 Id를 저장할 수 있는 setState 함수를 전달한다. 

2. URL을 통한 이슈 필터 조회 오류 
레이블 페이지에서 레이블을 클릭하거나 URL에 쿼리문을 작성하여 레이블을 이슈 필터조회할 때 같은 레이블이 중복으로 쿼리문에 담기는 오류를 발견했다. 
  - Issues 페이지 컴포넌트 마운트시 필터 상태를 초기화하는 로직을 추가함으로 해결했다.   
