### PR TITLE
Pagination UI 및 기능 구현, 필터 기능 일부 수정

### DIFF
--- a/src/components/Organisms/Pagination/helper.ts
+++ b/src/components/Organisms/Pagination/helper.ts
@@ -1,0 +1,19 @@
+export const buttonLogic = (totalPage: number, currentPage: number) => {
+  if (totalPage <= 7) {
+    const totalArray = Array.from({ length: totalPage }, (_, index) => index + 1);
+    return totalArray;
+  }
+
+  if (currentPage < 5) {
+    const firstArray = Array.from({ length: 5 }, (_, index) => index + 1);
+    return [...firstArray, '...', totalPage];
+  }
+
+  if (totalPage - 5 < currentPage) {
+    const lastArray = Array.from({ length: 5 }, (_, index) => totalPage - 4 + index);
+    return [1, '...', ...lastArray];
+  }
+
+  const innerArray = Array.from({ length: 3 }, (_, index) => currentPage - 1 + index);
+  return [1, '...', ...innerArray, '...', totalPage];
+};

--- a/src/components/Organisms/Pagination/index.stories.tsx
+++ b/src/components/Organisms/Pagination/index.stories.tsx
@@ -1,11 +1,12 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Pagination from '@/components/Organisms/Pagination';
+import { issues } from '@/mocks/tables/issue';
 
 export default {
   title: 'Organisms/Pagination',
   component: Pagination,
 } as ComponentMeta<typeof Pagination>;
 
-const Template: ComponentStory<typeof Pagination> = () => <Pagination />;
+const Template: ComponentStory<typeof Pagination> = () => <Pagination issuesData={issues.issues} />;
 
 export const Initial = Template.bind({});

--- a/src/components/Organisms/Pagination/index.stories.tsx
+++ b/src/components/Organisms/Pagination/index.stories.tsx
@@ -1,12 +1,27 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import Pagination from '@/components/Organisms/Pagination';
-import { issues } from '@/mocks/tables/issue';
 
 export default {
   title: 'Organisms/Pagination',
   component: Pagination,
 } as ComponentMeta<typeof Pagination>;
 
-const Template: ComponentStory<typeof Pagination> = () => <Pagination issuesData={issues.issues} />;
+const Template: ComponentStory<typeof Pagination> = (args) => <Pagination {...args} />;
 
 export const Initial = Template.bind({});
+Initial.args = {
+  totalPages: 20,
+  currentPage: 0,
+};
+
+export const Center = Template.bind({});
+Center.args = {
+  totalPages: 20,
+  currentPage: 11,
+};
+
+export const Tail = Template.bind({});
+Tail.args = {
+  totalPages: 20,
+  currentPage: 19,
+};

--- a/src/components/Organisms/Pagination/index.styled.ts
+++ b/src/components/Organisms/Pagination/index.styled.ts
@@ -4,11 +4,11 @@ import { StyledNavLinks } from '@/components/Molecules/NavLink/index.styles';
 export const Pagination = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
   gap: 20px;
-  margin-top: 100px;
+  margin: 40px 0;
 
   ${StyledNavLinks} {
     a {
-      ${({ theme }) => theme.FONTSTYLES.LINK_MEDIUM};
+      ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
       border: 1px solid transparent;
       border-radius: 6px;
       padding: 0px 12px;
@@ -19,12 +19,16 @@ export const Pagination = styled.div`
     }
 
     a.isActive {
-      background: ${({ theme }) => theme.COLORS.PRIMARY.DARK_BLUE};
+      background: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
       color: ${({ theme }) => theme.COLORS.OFF_WHITE};
     }
 
     a + a {
       margin-left: 5px;
     }
+  }
+
+  button:hover:not([disabled]) {
+    color: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
   }
 `;

--- a/src/components/Organisms/Pagination/index.styled.ts
+++ b/src/components/Organisms/Pagination/index.styled.ts
@@ -1,34 +1,33 @@
 import styled from 'styled-components';
-import { StyledNavLinks } from '@/components/Molecules/NavLink/index.styles';
 
 export const Pagination = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
   gap: 20px;
   margin: 40px 0;
 
-  ${StyledNavLinks} {
-    a {
-      ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
-      border: 1px solid transparent;
-      border-radius: 6px;
-      padding: 0px 12px;
-
-      &:hover {
-        border: 1px solid ${({ theme }) => theme.COLORS.LINE};
-      }
-    }
-
-    a.isActive {
-      background: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
-      color: ${({ theme }) => theme.COLORS.OFF_WHITE};
-    }
-
-    a + a {
-      margin-left: 5px;
-    }
-  }
-
   button:hover:not([disabled]) {
     color: ${({ theme }) => theme.COLORS.PRIMARY.BLUE};
   }
+
+  ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
+`;
+
+export const PaginationNumberButton = styled.button<{ isActive: boolean }>`
+  padding: 0 12px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  ${({ isActive, theme }) =>
+    isActive
+      ? `background: ${theme.COLORS.PRIMARY.BLUE}; color: ${theme.COLORS.OFF_WHITE};
+      &&&:hover:not([disabled]) {
+        color: ${theme.COLORS.OFF_WHITE};
+      }
+      `
+      : `background: transparent;
+      &:hover {
+        border: 1px solid ${theme.COLORS.LINE};
+        background: ${theme.COLORS.OFF_WHITE};
+      }
+      `};
+  ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
 `;

--- a/src/components/Organisms/Pagination/index.tsx
+++ b/src/components/Organisms/Pagination/index.tsx
@@ -1,37 +1,50 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
 import { useRecoilValue } from 'recoil';
+import { FilterStatsState } from '@/stores/filter';
+
+import { IssueTypes, PageTypes } from '@/api/issue/types';
+
 import * as S from '@/components/Organisms/Pagination/index.styled';
 import NavLink from '@/components/Molecules/NavLink';
-import { FilterStatsState, PageState } from '@/stores/filter';
+import Button from '@/components/Atoms/Button';
 
-const Paginiation = (): JSX.Element => {
-  const pageState = useRecoilValue(PageState);
+const Paginiation = ({ issuesData }: { issuesData: IssueTypes & PageTypes }): JSX.Element => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const pageParams = Number(searchParams.get('page')) || 0;
+
   const { queries } = useRecoilValue(FilterStatsState);
+  const { first, last, totalPages } = issuesData;
+
+  const navData = (pages: number) => {
+    const data = Array.from({ length: pages }, (_, index) => ({
+      link: `/issues?page=${index}&q=${queries}`,
+      title: `${index + 1}`,
+      dataId: `page ${index + 1}`,
+    }));
+
+    return data;
+  };
+
   return (
     <S.Pagination>
-      <NavLink
-        navData={[
-          {
-            link: `/issues?page=${pageState - 1}&q=${queries}`,
-            title: '< Previous',
-            dataId: 'previous page',
-          },
-          {
-            link: `/issues?page=0&q=${queries}`,
-            title: '1',
-            dataId: 'page 1',
-          },
-          {
-            link: `/issues?page=1&q=${queries}`,
-            title: '2',
-            dataId: 'page 2',
-          },
-          {
-            link: `/issues?page=${pageState + 1}&q=${queries}`,
-            title: 'Next >',
-            dataId: 'next page',
-          },
-        ]}
-        defaultActive="page 1"
+      <Button
+        buttonStyle="NO_BORDER"
+        label="< PREVIOUS"
+        size="MEDIUM"
+        disabled={first}
+        handleOnClick={() => navigate(`/issues?page=${pageParams > 0 ? pageParams - 1 : 0}&q=${queries}`)}
+      />
+      <NavLink navData={navData(totalPages)} defaultActive="page 1" />
+      <Button
+        buttonStyle="NO_BORDER"
+        label="NEXT >"
+        size="MEDIUM"
+        disabled={last}
+        handleOnClick={() =>
+          navigate(`/issues?page=${pageParams < totalPages ? pageParams + 1 : totalPages}&q=${queries}`)
+        }
       />
     </S.Pagination>
   );

--- a/src/components/Organisms/Pagination/index.tsx
+++ b/src/components/Organisms/Pagination/index.tsx
@@ -1,30 +1,37 @@
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useRecoilValue } from 'recoil';
 import { FilterStatsState } from '@/stores/filter';
 
-import { IssueTypes, PageTypes } from '@/api/issue/types';
-
 import * as S from '@/components/Organisms/Pagination/index.styled';
-import NavLink from '@/components/Molecules/NavLink';
 import Button from '@/components/Atoms/Button';
+import { buttonLogic } from '@/components/Organisms/Pagination/helper';
 
-const Paginiation = ({ issuesData }: { issuesData: IssueTypes & PageTypes }): JSX.Element => {
+const Paginiation = ({ totalPages, currentPage }: { totalPages: number; currentPage: number }): JSX.Element => {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const pageParams = Number(searchParams.get('page')) || 0;
-
   const { queries } = useRecoilValue(FilterStatsState);
-  const { first, last, totalPages } = issuesData;
 
-  const navData = (pages: number) => {
-    const data = Array.from({ length: pages }, (_, index) => ({
-      link: `/issues?page=${index}&q=${queries}`,
-      title: `${index + 1}`,
-      dataId: `page ${index + 1}`,
-    }));
+  const PaginationButtons = (total: number, current: number) => {
+    const isNumber = (x: any): x is number => typeof x === 'number';
 
-    return data;
+    const buttons = buttonLogic(total, current).map((el) => {
+      if (isNumber(el)) {
+        return (
+          <S.PaginationNumberButton
+            key={`page-btn-${el}`}
+            type="button"
+            isActive={el - 1 === currentPage}
+            onClick={() => navigate(`/issues?page=${el - 1}&q=${queries}`)}
+          >
+            {el}
+          </S.PaginationNumberButton>
+        );
+      }
+
+      return <div>…</div>;
+    });
+
+    return buttons;
   };
 
   return (
@@ -33,17 +40,17 @@ const Paginiation = ({ issuesData }: { issuesData: IssueTypes & PageTypes }): JS
         buttonStyle="NO_BORDER"
         label="< PREVIOUS"
         size="MEDIUM"
-        disabled={first}
-        handleOnClick={() => navigate(`/issues?page=${pageParams > 0 ? pageParams - 1 : 0}&q=${queries}`)}
+        disabled={currentPage <= 0}
+        handleOnClick={() => navigate(`/issues?page=${currentPage > 0 ? currentPage - 1 : 0}&q=${queries}`)}
       />
-      <NavLink navData={navData(totalPages)} defaultActive="page 1" />
+      {PaginationButtons(totalPages, currentPage + 1)}
       <Button
         buttonStyle="NO_BORDER"
         label="NEXT >"
         size="MEDIUM"
-        disabled={last}
+        disabled={totalPages <= currentPage + 1}
         handleOnClick={() =>
-          navigate(`/issues?page=${pageParams < totalPages ? pageParams + 1 : totalPages}&q=${queries}`)
+          navigate(`/issues?page=${currentPage < totalPages ? currentPage + 1 : totalPages}&q=${queries}`)
         }
       />
     </S.Pagination>

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,5 +1,5 @@
-import { FilterState, NoFilterKeysType } from '@/stores/filter';
-import { useRecoilState } from 'recoil';
+import { FilterState, NoFilterKeysType, PageState } from '@/stores/filter';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 export const stateFilterReg = /^is:/g;
 export const noneFilterReg = /^no:/g;
@@ -15,6 +15,7 @@ export const URLIssueStateReg = new RegExp(`${encodeURIComponent(OPEN_QUERY)}|${
 
 const useFilter = () => {
   const [filterState, setFilterState] = useRecoilState(FilterState);
+  const setPageState = useSetRecoilState(PageState);
 
   const isExistedFilter = (filter: string): boolean => {
     const [key, value] = filter.split(':');
@@ -45,6 +46,7 @@ const useFilter = () => {
       const filterExistedKey = prevState.no.filter((e) => e !== key);
       return { ...prevState, [key]: newValue, no: filterExistedKey };
     });
+    setPageState(0);
   };
 
   const setRemovedFilterState = (filter: string) => {

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -52,16 +52,20 @@ const Issues = () => {
     });
   };
 
+  // 쿼리가 변경되면 해당하는 결과로 이동한다.
   useEffect(() => {
     if (!document.location.search && filterState === initFilterState) return;
-
     naviagate(`/issues?page=${page}&q=${queries}`);
   }, [queries]);
 
   useEffect(() => {
     setPageState(pageParams);
-    setURLQueriesToFilterState();
-  }, []);
+
+    // 뒤로가기 시 url의 쿼리와 FilterState를 일치시킨다.
+    if (decodeURIComponent(queries).replaceAll('+', ' ') !== decodeURIComponent(queriesParams!)) {
+      setURLQueriesToFilterState();
+    }
+  }, [queriesParams]);
 
   return (
     <>

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -68,7 +68,6 @@ const Issues = () => {
     }
     // 이전 페이지가 루트인 경우 FilterState를 초기화한다.
     if (!queriesParams && !pageParams) {
-      console.log(null);
       resetFilterState();
     }
   }, [queriesParams]);

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -78,7 +78,9 @@ const Issues = () => {
         </S.SubNav>
       </S.NavInline>
       <IssueTable issuesData={issues!} milestoneData={milestoneData!} labelData={labelData!} />
-      {!!issues!.issues.content.length && <Paginiation issuesData={issues!.issues} />}
+      {!!issues!.issues.content.length && (
+        <Paginiation totalPages={issues!.issues.totalPages} currentPage={pageParams} />
+      )}
     </>
   );
 };

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -19,6 +19,7 @@ import useFetchMilestone from '@/api/milestone/useFetchMilestone';
 
 import useFilter, { parsingFilterReg } from '@/hooks/useFilter';
 import { labelMilestone } from '@/components/Molecules/NavLink/options';
+import Paginiation from '@/components/Organisms/Pagination';
 
 const Issues = () => {
   const naviagate = useNavigate();
@@ -77,6 +78,7 @@ const Issues = () => {
         </S.SubNav>
       </S.NavInline>
       <IssueTable issuesData={issues!} milestoneData={milestoneData!} labelData={labelData!} />
+      {!!issues!.issues.content.length && <Paginiation issuesData={issues!.issues} />}
     </>
   );
 };

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -22,7 +22,8 @@ import { labelMilestone } from '@/components/Molecules/NavLink/options';
 import Paginiation from '@/components/Organisms/Pagination';
 
 const Issues = () => {
-  const naviagate = useNavigate();
+  const navigate = useNavigate();
+
   const [searchParams] = useSearchParams();
   const pageParams = Number(searchParams.get('page')) || 0;
   const queriesParams = searchParams.get('q');
@@ -55,7 +56,7 @@ const Issues = () => {
   // 쿼리가 변경되면 해당하는 결과로 이동한다.
   useEffect(() => {
     if (!document.location.search && filterState === initFilterState) return;
-    naviagate(`/issues?page=${page}&q=${queries}`);
+    navigate(`/issues?page=${page}&q=${queries}`);
   }, [queries]);
 
   useEffect(() => {

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -65,6 +65,11 @@ const Issues = () => {
     if (decodeURIComponent(queries).replaceAll('+', ' ') !== decodeURIComponent(queriesParams!)) {
       setURLQueriesToFilterState();
     }
+    // 이전 페이지가 루트인 경우 FilterState를 초기화한다.
+    if (!queriesParams && !pageParams) {
+      console.log(null);
+      resetFilterState();
+    }
   }, [queriesParams]);
 
   return (


### PR DESCRIPTION
## Description
issues 페이지의 issueTable을 위한 Pagination 기능 구현
숫자 버튼이 렌더링 되는 방식은 MUI의 [Pagination](https://mui.com/material-ui/react-pagination/#main-content)을 참고해서 구현함

## Commits
- NavLink 컴포넌트(a태그)로 구현된 컴포넌트를 button 컴포넌트로 리팩토링 했다.
- Props로 전체 페이지 수와 현재 페이지를 받아서 범위에 해당하는 숫자 버튼을 렌더링 한다. (아래 결과 참조)
    - 페이지에 따른 스토리 추가

### 필터 관련 수정사항
- 뒤로가기 시 FilterState를 URL 쿼리와 일치하도록 수정
- 뒤로가기 시 이전 페이지가 루트 페이지면 FilterState를 리셋하도록 수정
- 필터 값 변경시 PageState를 초기화 하도록 수정

### 결과

#### Pagination 적용화면
![화면 기록 2022-11-24 오전 3 19 09](https://user-images.githubusercontent.com/85747667/204005867-8256caf2-f4c9-4c32-b250-b9e54f407c59.gif)

#### 전체 페이지 수와 현재 페이지에 따른 숫자 버튼의 모습
<img width="1053" alt="스크린샷 2022-11-24 오전 3 10 45" src="https://user-images.githubusercontent.com/85747667/204005984-94316528-9b3f-436c-b816-82531db31811.png">

#### 뒤로가기 시 필터 상태 변화
![화면 기록 2022-11-30 오후 3 37 54](https://user-images.githubusercontent.com/85747667/204725585-de82ef57-9b99-438f-9550-428707a748a0.gif)

