### PR TITLE
에러바운더리와 에러 관련 수정

### DIFF
--- a/src/api/sign/useLogout.ts
+++ b/src/api/sign/useLogout.ts
@@ -4,19 +4,34 @@ import { signout } from '@/api/sign';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
 import OAuthState from '@/stores/auth';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
+import { AxiosError } from 'axios';
+import { ErrorMessage } from '@/api/constants';
 
 const useLogout = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const setIsOAuth = useSetRecoilState(OAuthState);
   const resetLoginUserInfo = useResetRecoilState(LoginUserInfoState);
+
+  const logoutLogic = () => {
+    queryClient.clear();
+    resetLoginUserInfo();
+    setIsOAuth(false);
+    localStorage.removeItem('Authentication');
+    navigate('/');
+  };
+
   const { mutate: useSignout } = useMutation(['signout'], signout, {
     onSuccess: () => {
-      queryClient.clear();
-      resetLoginUserInfo();
-      setIsOAuth(false);
-      localStorage.removeItem('Authentication');
-      navigate('/');
+      logoutLogic();
+    },
+    onError: (err) => {
+      const Error = err as AxiosError<ErrorMessage>;
+      const errorCode = Error.response?.data.errorCode;
+
+      if (errorCode === 1002 || errorCode === 1004) {
+        logoutLogic();
+      }
     },
   });
 

--- a/src/components/ErrorBoundary/InternalServerError.tsx
+++ b/src/components/ErrorBoundary/InternalServerError.tsx
@@ -27,8 +27,18 @@ const StyledInternalServerError = styled.div`
   }
 `;
 
-const InternalServerError = () => {
+const InternalServerError = ({ resetError }: { resetError: () => void }) => {
   const navigate = useNavigate();
+
+  const backToPreviousPage = () => {
+    resetError();
+    navigate(-1);
+  };
+
+  const backToMainPage = () => {
+    resetError();
+    navigate('/');
+  };
 
   return (
     <StyledInternalServerError>
@@ -40,8 +50,8 @@ const InternalServerError = () => {
         잠시 후 다시 확인해주세요.
       </p>
       <div className="nav_btns">
-        <Button buttonStyle="STANDARD" label="이전" size="MEDIUM" handleOnClick={() => navigate(-1)} />
-        <Button buttonStyle="STANDARD" label="메인으로" size="MEDIUM" handleOnClick={() => navigate('/')} />
+        <Button buttonStyle="STANDARD" label="이전" size="MEDIUM" handleOnClick={backToPreviousPage} />
+        <Button buttonStyle="STANDARD" label="메인으로" size="MEDIUM" handleOnClick={backToMainPage} />
       </div>
     </StyledInternalServerError>
   );

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -101,7 +101,7 @@ class ErrorBoundary extends React.Component<
       }
 
       if (fallbackRender) {
-        this.fallbackUIRender(fallbackRender, data);
+        return this.fallbackUIRender(fallbackRender, data);
       }
 
       switch (data.errorCode) {

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -97,7 +97,7 @@ class ErrorBoundary extends React.Component<
       const { status, data } = error.response!;
 
       if (status === 500) {
-        return <InternalServerError />;
+        return <InternalServerError resetError={() => this.resetState()} />;
       }
 
       if (fallbackRender) {


### PR DESCRIPTION
## Description
- 에러바운더리의 fallback UI가 동작하지 않는 오류 수정
- 에러바운더리의 505 에러 관련 컴포넌트의 기능 수정
- 리프레시 토큰 만료인 상태에서 로그아웃 요청시 로그인 만료 UI가 보이지 않게 수정

## Commits
#### 에러바운더리의 fallback UI가 동작하지 않는 오류
```JSX
class ErrorBoundary extends React.Component<
  React.PropsWithRef<PropsWithChildren<ErrorBoundaryProps>>,
  ErrorBoundaryState
>
 {
    /* 이하 생략 */

  render() {
    const { children, fallbackRender } = this.props;
    const { error } = this.state;

    if (error) {
      const { status, data } = error.response!;

      if (status === 500) {
        return <InternalServerError resetError={() => this.resetState()} />;
      }

      if (fallbackRender) {
        return this.fallbackUIRender(fallbackRender, data);
      }
}

```
 if (fallbackRender) 문에 return을 넣어서 해결했다.

#### 에러바운더리의 505 에러 관련 InternalServerError 컴포넌트 수정

505 에러 발생시 InternalServerError 컴포넌트의 버튼을 클릭하면 라우터 이동만 되고 에러상태는 그대로였기 때문에 해당 UI가 그대로 남아있었다.
-> InternalServerError 컴포넌트에 에러를 리셋하는 로직을 넣어서 해결했다.

#### 리프레시 토큰 만료인 상태에서 로그아웃 요청시 로그인 만료 UI가 보이지 않게 수정
기존에는 로그아웃 클릭시 리프레시 토큰이 유효하지 않으면(없으면) 1002, 1004 에러에 대한 ExpiredLogin 컴포넌트가 렌더링 된다. 그래서 로그아웃을 시도했는데 로그인이 만료되었다는 UI가 보여지는 과정이 어색하다고 느껴져서 해당 에러가 나타나도 기존의 로그아웃과 동일한 로직이 실행되도록 변경했다.

### 결과

ex) 실행, 테스트 결과 또는 사진 첨부

#### 수정 전
![화면 기록 2022-12-01 오후 9 37 56](https://user-images.githubusercontent.com/85747667/205055008-b09c029d-9001-4fe3-8780-c9f1b6ec16bf.gif)

#### 수정 후
![화면 기록 2022-12-01 오후 9 38 18](https://user-images.githubusercontent.com/85747667/205055208-a8143064-e47b-4eef-9d89-9752d22ebf35.gif)
