### PR TITLE
🐛 이슈 날짜 관련 수정

### DIFF
--- a/src/components/Organisms/IssueHeader/index.tsx
+++ b/src/components/Organisms/IssueHeader/index.tsx
@@ -9,16 +9,12 @@ import HeaderInline from '@/components/Organisms/IssueHeader/HeaderInline';
 import calcTimeForToday from '@/utils/calcForTimeToday';
 import { ContentTypes } from '@/api/issue/types';
 
-type IssueHeaderTypes = Pick<ContentTypes, 'id' | 'title' | 'closed' | 'createdAt' | 'lastModifiedAt' | 'author'> & {
+type IssueHeaderTypes = Pick<ContentTypes, 'id' | 'title' | 'closed' | 'createdAt' | 'author'> & {
   commentNum: number;
 };
 
-const IssueHeader = ({ id, closed, title, createdAt, lastModifiedAt, author, commentNum }: IssueHeaderTypes) => {
-  const issueState = closed ? '닫혔' : '열렸';
-  const timeStamp = createdAt === lastModifiedAt ? createdAt : lastModifiedAt;
-  const issueStateSummary = `이 이슈가 ${calcTimeForToday(timeStamp)}에 ${
-    author.nickname
-  }님에 의해 ${issueState}습니다.`;
+const IssueHeader = ({ id, closed, title, createdAt, author, commentNum }: IssueHeaderTypes) => {
+  const issueOpenSummary = `이 이슈가 ${calcTimeForToday(createdAt)}에 ${author.nickname}님에 의해 열렸습니다.`;
 
   return (
     <S.IssueHeader>
@@ -31,7 +27,7 @@ const IssueHeader = ({ id, closed, title, createdAt, lastModifiedAt, author, com
           lineColor={closed ? COLORS.SECONDORY.PURPLE : COLORS.PRIMARY.BLUE}
           title={closed ? '닫힌 이슈' : '열린 이슈'}
         />
-        <span>{issueStateSummary}</span>
+        <span>{issueOpenSummary}</span>
         <span className="splitLine">∙</span>
         <span>{`코멘트 ${commentNum}개`}</span>
       </S.Info>

--- a/src/components/Organisms/IssueTable/IssueItem/index.tsx
+++ b/src/components/Organisms/IssueTable/IssueItem/index.tsx
@@ -16,16 +16,33 @@ import { ContentTypes } from '@/api/issue/types';
 import { FilterState } from '@/stores/filter';
 
 const IssueItem = (issueInfo: ContentTypes) => {
-  const { id, title, closed, issueLabels, author, issueAssignees, createdAt, lastModifiedAt, milestone } = issueInfo;
+  const {
+    id,
+    title,
+    closed,
+    issueLabels,
+    author,
+    issueAssignees,
+    createdAt,
+    lastModifiedAt,
+    milestone,
+    issueHistories,
+  } = issueInfo;
 
   const checkState = useRecoilValue(CheckState);
   const setFilterState = useSetRecoilState(FilterState);
 
   const issueLink = `/issues/${id}`;
   const milestoneLink = `/milestone/${id}`;
-  // eslint-disable-next-line no-nested-ternary
-  const issueState = closed ? '닫혔습니다' : createdAt === lastModifiedAt ? '작성되었습니다' : '열렸습니다';
-  const timeStamp = createdAt === lastModifiedAt ? createdAt : lastModifiedAt;
+
+  const issueState = closed ? '닫혔습니다' : '열렸습니다';
+  const closeIssueHistories = issueHistories.filter((history) => history.action === 'CLOSE_ISSUE');
+
+  const lastCloseIssueHistory = closeIssueHistories.length
+    ? closeIssueHistories[closeIssueHistories.length - 1].modifiedAt
+    : lastModifiedAt;
+
+  const timeStamp = closed ? lastCloseIssueHistory : createdAt;
   const issueSummary = `이 이슈가 ${calcTimeForToday(timeStamp)}, ${author.nickname}님에 의해 ${issueState}`;
 
   const isChecked = !!checkState.child.find((checkboxId) => checkboxId === id);

--- a/src/pages/Private/IssueDetail/index.tsx
+++ b/src/pages/Private/IssueDetail/index.tsx
@@ -66,7 +66,6 @@ const IssueDetail = (): JSX.Element => {
         closed={closed}
         title={title}
         createdAt={createdAt}
-        lastModifiedAt={lastModifiedAt}
         author={author}
         commentNum={comments.length}
       />

--- a/src/utils/calcForTimeToday.ts
+++ b/src/utils/calcForTimeToday.ts
@@ -1,24 +1,28 @@
+const dateConverter = (today: Date, inputDate: Date) => {
+  const year = inputDate.getFullYear();
+  const month = inputDate.getMonth() + 1;
+  const date = inputDate.getDate();
+
+  return today.getFullYear() === year ? `${month}월 ${date}일` : `${year}년 ${month}월 ${date}일`;
+};
+
 const calcTimeForToday = (timeStampValue: string) => {
   const today = new Date();
   const timeStamp = new Date(timeStampValue);
   const timeDifference = today.getTime() - timeStamp.getTime();
-  const [milliSecond, second, minute, hour, day, month, year] = [1000, 1, 60, 60, 24, 30, 12];
+  const [milliSecond, second, minute, hour, day, month] = [1000, 1, 60, 60, 24, 30];
 
   const minuteDifference = Math.floor(timeDifference / milliSecond / minute);
-  if (minuteDifference < second) return '방금전';
-  if (minuteDifference < hour) return `${minuteDifference}분전`;
+  if (minuteDifference < second) return '방금 전';
+  if (minuteDifference < hour) return `${minuteDifference}분 전`;
 
   const hourDifference = Math.floor(minuteDifference / hour);
-  if (hourDifference < day) return `${hourDifference}시간전`;
+  if (hourDifference < day) return `${hourDifference}시간 전`;
 
   const dayDifference = Math.floor(hourDifference / day);
-  if (dayDifference < month) return `${dayDifference}일전`;
+  if (dayDifference < month && today.getMonth() === timeStamp.getMonth()) return `${dayDifference}일 전`;
 
-  const monthDifference = Math.floor(dayDifference / month);
-  if (monthDifference < year) return `${monthDifference}개월전`;
-
-  const yearDifference = Math.floor(monthDifference / year);
-  return `${yearDifference}년전`;
+  return dateConverter(today, timeStamp);
 };
 
 export default calcTimeForToday;


### PR DESCRIPTION
## Description
- #49 

## Commits
###  날짜 표기법 수정
변경 전: n년 전, n개월 전, n일 전으로 표기
- 해당 월이 아닌 경우 부터 월 일로 표기한다.
- 년도가 변경되면 년 월 일로 표기한다.

### 이슈 테이블에서 표기되는 date 값 변경
- 열린 상태일때는 처음 생성된 date를 표시한다. (createdAt)
- 닫힌 상태일때는 히스토리의 값을 파싱해서 마지막으로 닫힌 상태의 date를 표시한다. (modifiedAt)
    - 서버측에서 생성한 데이터 중 닫힌 이슈에 닫힘 히스토리가 존재하지 않는 경우가 있어서 임의로 닫힌 히스토리가 없는 경우 lastModifiedAt 값으로 date를 표시한다.

```jsx
// IssueItem
  const lastCloseIssueHistory = closeIssueHistories.length
    ? closeIssueHistories[closeIssueHistories.length - 1].modifiedAt
    : lastModifiedAt;
```

#### 열린 이슈

<img width="617" alt="스크린샷 2022-12-07 오후 11 55 39" src="https://user-images.githubusercontent.com/85747667/206212468-5a064815-6173-40e8-b74c-06933378df74.png">

#### 닫힌 이슈

<img width="621" alt="스크린샷 2022-12-07 오후 11 55 50" src="https://user-images.githubusercontent.com/85747667/206212503-0b17c1e1-5405-4714-9da4-67acd8efff76.png">


### 이슈 디테일 페이지에서 표기되는 date 값 변경
- 깃허브를 참고하여 이슈가 생성된 date를 보이도록 수정했다.

<img width="785" alt="스크린샷 2022-12-07 오후 11 54 37" src="https://user-images.githubusercontent.com/85747667/206211845-d69874da-40a6-420f-8cfc-b94cae9cb8c3.png">
