### PR TITLE
♻️ 검색 순으로 필터바에 렌더링 및 마일스톤 페이지 필터 기능 구현

### DIFF
--- a/src/api/issue/index.ts
+++ b/src/api/issue/index.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 import { ContentTypes, IssuesTypes } from '@/api/issue/types';
 import { NEW_ISSUE_FORM_TYPES } from '@/stores/newIssue';
-import { parsingFilterReg } from '@/hooks/useFilter';
 
 interface Idtypes {
   issueId: number;
@@ -11,13 +10,9 @@ interface Idtypes {
 }
 
 export const getIssuesData = async (page: number, queryString: string): Promise<IssuesTypes> => {
-  const queries =
-    queryString
-      .match(parsingFilterReg)
-      ?.map((e) => encodeURIComponent(e))
-      .join('+') || '';
-
-  const { data: issuesData } = await axios.get<IssuesTypes>(`api/issues?page=${page}&q=${encodeURIComponent(queries)}`);
+  const { data: issuesData } = await axios.get<IssuesTypes>(
+    `api/issues?page=${page}&q=${encodeURIComponent(queryString)}`,
+  );
   return issuesData;
 };
 

--- a/src/api/issue/useFetchIssue.ts
+++ b/src/api/issue/useFetchIssue.ts
@@ -14,7 +14,7 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useResetRecoilState } from 'recoil';
 import { NewIssueFormState } from '@/stores/newIssue';
-import { OPEN_QUERY } from '@/hooks/useFilter';
+import useFilter from '@/hooks/useFilter';
 import notifyError from '@/api/alertHelper';
 
 const useFetchIssue = (id?: number) => {
@@ -22,9 +22,9 @@ const useFetchIssue = (id?: number) => {
   const navigate = useNavigate();
   const resetNewIssueFormState = useResetRecoilState(NewIssueFormState);
 
-  const useIssuesData = (page: number, queryString: string | null) => {
-    const issueStateQuery = !document.location.search ? OPEN_QUERY : '';
-    const queries = queryString || issueStateQuery;
+  const useIssuesData = (page: number, queryString: string) => {
+    const { changeFilterToURL } = useFilter();
+    const queries = changeFilterToURL(queryString);
 
     return useQuery<IssuesTypes>(['issues', page, queries], () => getIssuesData(page, queries));
   };

--- a/src/components/Molecules/Dropdown/Panel/List/index.styles.ts
+++ b/src/components/Molecules/Dropdown/Panel/List/index.styles.ts
@@ -25,7 +25,6 @@ export const Panel = styled.menu`
 export const PanelItem = styled.li`
   width: 100%;
   cursor: pointer;
-  padding: 8px 16px;
   border-top: 1px solid ${({ theme }) => theme.COLORS.LINE};
   background: ${({ theme }) => theme.COLORS.OFF_WHITE};
   color: ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
@@ -47,6 +46,7 @@ export const PanelItem = styled.li`
   label {
     ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'space-between' })};
     cursor: pointer;
+    padding: 4px 16px;
   }
 `;
 
@@ -58,6 +58,8 @@ export const CheckBoxItem = styled.input`
 
   & ~ label {
     height: 28px;
+    padding: 4px 16px;
+    height: fit-content;
 
     span {
       display: inline-block;

--- a/src/components/Molecules/Dropdown/mock.tsx
+++ b/src/components/Molecules/Dropdown/mock.tsx
@@ -3,6 +3,7 @@ import { IssueTypes, DropdownTypes, ListPanelTypes, ReactionPanelTypes } from '@
 import { COLORS } from '@/styles/theme';
 import { REACTIONS } from '@/components/Molecules/Dropdown/Panel/Reaction/mock';
 import { LabelTypes, MilestoneTypes, UserTypes } from '@/api/issue/types';
+import { CLOSED_QUERY, OPEN_QUERY } from '@/hooks/useFilter';
 
 export const UNUSED_OPTIONS = {
   ASSIGNEE: {
@@ -22,7 +23,7 @@ export const UNUSED_OPTIONS = {
 export const ISSUE_FILTER_LIST: IssueTypes[] = [
   {
     id: 0,
-    dataId: 'is:open',
+    dataId: OPEN_QUERY,
     title: '열린 이슈',
   },
   {
@@ -42,7 +43,7 @@ export const ISSUE_FILTER_LIST: IssueTypes[] = [
   },
   {
     id: 4,
-    dataId: 'is:closed',
+    dataId: CLOSED_QUERY,
     title: '닫힌 이슈',
   },
 ];

--- a/src/components/Molecules/FilterBar/index.tsx
+++ b/src/components/Molecules/FilterBar/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
-import { FilterState, FilterStatsState } from '@/stores/filter';
+import React, { useState, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 import * as S from '@/components/Molecules/FilterBar/index.styles';
 
@@ -11,7 +11,7 @@ import Dropdown from '@/components/Molecules/Dropdown';
 import useInput from '@/hooks/useInput';
 import { FILTERBAR_CLEAR_BUTTON_PROPS } from '@/components/Molecules/FilterBar/mocks';
 import { DropdownTypes, ListPanelTypes } from '@/components/Molecules/Dropdown/types';
-import useFilter, { parsingFilterReg, stateFilterReg } from '@/hooks/useFilter';
+import useFilter, { OPEN_QUERY } from '@/hooks/useFilter';
 import debounce from '@/utils/debounce';
 import { FilterState, FilterStatsState } from '@/stores/filter';
 
@@ -23,62 +23,52 @@ export type FILTERBAR_INFO_TYPES = {
   INPUT: InputTypes;
 };
 
-const DELAY = 100;
+const DELAY = 50;
 
 const FilterBar = ({ ...props }: FILTERBAR_INFO_TYPES) => {
   const { DROPDOWN, INPUT } = props;
 
   const timerId = useRef<number>(0);
-  const { filterBarString, isFiltering } = useRecoilValue(FilterStatsState);
-  const setFilterState = useSetRecoilState(FilterState);
-  const resetFilterValue = useResetRecoilState(FilterState);
-  const { isActive, onClickInput, onBlurInput } = useInput();
   const queries = useRecoilValue(FilterState);
   const { isFiltering } = useRecoilValue(FilterStatsState);
 
   const [filterBarValue, setFilterBarValue] = useState<string>(queries);
+  const { isActive, onClickInput, onBlurInput } = useInput();
+  const { searchFilter } = useFilter();
+  const meReg = /\w+:@me$/;
 
-  const isChecked = (dataId: string) => {
-    if (dataId.match(stateFilterReg)) return filterBarString === dataId;
-    return filterBarString === `is:open ${dataId}`;
+  const isChecked = (dataId: string): boolean => {
+    if (meReg.test(dataId)) {
+      return queries === `${OPEN_QUERY} ${dataId}`;
+    }
+
+    return queries === dataId;
   };
 
   const filterIssues = (target: HTMLInputElement) => {
-    const clickedPanelDataId = target.dataset.id!;
-    resetFilterValue();
-    setParsingFilterState(clickedPanelDataId!);
+    const dataId = target.dataset.id!;
+
+    if (meReg.test(dataId)) {
+      searchFilter(`${OPEN_QUERY} ${dataId}`);
+      return;
+    }
+
+    searchFilter(dataId);
   };
 
   const handleChangeFilterBar = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const queries = event.target.value;
-    if (!queries) return setFilterBarInputValue('');
+    const queriesValue = event.target.value;
+    if (!queriesValue) return setFilterBarValue('');
 
-    setFilterBarInputValue(queries);
+    setFilterBarValue(queriesValue);
   };
 
   const handleTypingFilterBar = debounce(timerId, handleChangeFilterBar, DELAY);
 
   const handleSubmitFilterBar = (event: React.ChangeEvent<HTMLFormElement>) => {
     event.preventDefault();
-
-    resetFilterValue();
-
-    if (!filterBarInputValue) {
-      setFilterState((prev) => ({ ...prev, is: 'all' }));
-      return;
-    }
-
-    setIssueState(filterBarInputValue);
-
-    const queriesArr = filterBarInputValue.match(parsingFilterReg);
-    queriesArr?.forEach((query: string) => {
-      setParsingFilterState(query);
-    });
+    searchFilter(filterBarValue);
   };
-
-  useEffect(() => {
-    setFilterBarInputValue(filterBarString);
-  }, [filterBarString]);
 
   return (
     <S.FilterBarContainer>
@@ -86,7 +76,7 @@ const FilterBar = ({ ...props }: FILTERBAR_INFO_TYPES) => {
         <Dropdown {...DROPDOWN(filterIssues, isChecked)} isActive={isActive} />
         <Input
           {...INPUT}
-          inputValue={filterBarString}
+          inputValue={queries}
           isActive={isActive}
           onClick={onClickInput}
           onBlur={onBlurInput}
@@ -94,7 +84,11 @@ const FilterBar = ({ ...props }: FILTERBAR_INFO_TYPES) => {
           onSubmit={handleSubmitFilterBar}
         />
       </S.FilterBar>
-      {isFiltering && <Button {...FILTERBAR_CLEAR_BUTTON_PROPS} handleOnClick={resetFilterValue} />}
+      {isFiltering && (
+        <Link to="/issues">
+          <Button {...FILTERBAR_CLEAR_BUTTON_PROPS} />
+        </Link>
+      )}
     </S.FilterBarContainer>
   );
 };

--- a/src/components/Molecules/FilterBar/index.tsx
+++ b/src/components/Molecules/FilterBar/index.tsx
@@ -13,6 +13,7 @@ import { FILTERBAR_CLEAR_BUTTON_PROPS } from '@/components/Molecules/FilterBar/m
 import { DropdownTypes, ListPanelTypes } from '@/components/Molecules/Dropdown/types';
 import useFilter, { parsingFilterReg, stateFilterReg } from '@/hooks/useFilter';
 import debounce from '@/utils/debounce';
+import { FilterState, FilterStatsState } from '@/stores/filter';
 
 export type FILTERBAR_INFO_TYPES = {
   DROPDOWN: (
@@ -32,9 +33,10 @@ const FilterBar = ({ ...props }: FILTERBAR_INFO_TYPES) => {
   const setFilterState = useSetRecoilState(FilterState);
   const resetFilterValue = useResetRecoilState(FilterState);
   const { isActive, onClickInput, onBlurInput } = useInput();
+  const queries = useRecoilValue(FilterState);
+  const { isFiltering } = useRecoilValue(FilterStatsState);
 
-  const [filterBarInputValue, setFilterBarInputValue] = useState<string>(filterBarString);
-  const { setIssueState, setParsingFilterState } = useFilter();
+  const [filterBarValue, setFilterBarValue] = useState<string>(queries);
 
   const isChecked = (dataId: string) => {
     if (dataId.match(stateFilterReg)) return filterBarString === dataId;

--- a/src/components/Molecules/NavLink/index.tsx
+++ b/src/components/Molecules/NavLink/index.tsx
@@ -17,21 +17,17 @@ export interface NavLinkTypes {
 
 const NavLink = ({ navData, navLinkStyle = 'NORMAL', defaultActive, handleOnClick }: NavLinkTypes) => {
   const { pathname, search } = document.location;
-  const url = pathname + search;
+  const url = decodeURIComponent(pathname + search);
 
   return (
     <S.StyledNavLinks navLinkStyle={navLinkStyle}>
       {navData.map(({ icon, title, link, dataId }) => {
-        const isActive = url === link;
         const isDefaultActive = !search && defaultActive === dataId;
+        const isActive = url.includes(link);
+        const active = isDefaultActive || isActive ? 'isActive' : '';
+
         return (
-          <S.StyledNavLink
-            key={title}
-            className={isActive || isDefaultActive ? 'isActive' : ''}
-            to={link}
-            data-id={dataId}
-            onClick={handleOnClick}
-          >
+          <S.StyledNavLink key={title} className={active} to={link} data-id={dataId} onClick={handleOnClick}>
             {icon}
             <span>{title}</span>
           </S.StyledNavLink>

--- a/src/components/Molecules/NavLink/options.tsx
+++ b/src/components/Molecules/NavLink/options.tsx
@@ -22,19 +22,22 @@ export const labelMilestone = (labelsNum?: number, milestonesNum?: number) => {
 
 export const openCloseIssue = (openIssueNum: number, closedIssueNum: number, page: number, queryString: string) => {
   const pageQuery = `/issues?page=${page}`;
-  const filterIssueStateQuery = queryString.replace(URLIssueStateReg, '');
+  const stateReg = /is:\w+/g;
+  const queries = (state: string) =>
+    stateReg.test(queryString) ? queryString.replace(stateReg, state) : `${state} ${queryString}`;
+
   return [
     {
       dataId: OPEN_QUERY,
       icon: <Icon icon="AlertCircle" stroke={COLORS.PRIMARY.BLUE} />,
       title: `열린 이슈 (${openIssueNum})`,
-      link: `${pageQuery}&q=${encodeURIComponent(OPEN_QUERY)}${filterIssueStateQuery}`,
+      link: `${pageQuery}&q=${queries(OPEN_QUERY)}`,
     },
     {
       dataId: CLOSED_QUERY,
       icon: <Icon icon="Archive" stroke={COLORS.SECONDORY.PURPLE} />,
       title: `닫힌 이슈 (${closedIssueNum})`,
-      link: `${pageQuery}&q=${encodeURIComponent(CLOSED_QUERY)}${filterIssueStateQuery}`,
+      link: `${pageQuery}&q=${queries(CLOSED_QUERY)}`,
     },
   ];
 };

--- a/src/components/Molecules/NavLink/options.tsx
+++ b/src/components/Molecules/NavLink/options.tsx
@@ -1,5 +1,5 @@
 import Icon from '@/components/Atoms/Icon';
-import { CLOSED_QUERY, OPEN_QUERY, URLIssueStateReg } from '@/hooks/useFilter';
+import { CLOSED_QUERY, OPEN_QUERY } from '@/hooks/useFilter';
 import { COLORS } from '@/styles/theme';
 
 export const labelMilestone = (labelsNum?: number, milestonesNum?: number) => {
@@ -25,13 +25,13 @@ export const openCloseIssue = (openIssueNum: number, closedIssueNum: number, pag
   const filterIssueStateQuery = queryString.replace(URLIssueStateReg, '');
   return [
     {
-      dataId: 'is:open',
+      dataId: OPEN_QUERY,
       icon: <Icon icon="AlertCircle" stroke={COLORS.PRIMARY.BLUE} />,
       title: `열린 이슈 (${openIssueNum})`,
       link: `${pageQuery}&q=${encodeURIComponent(OPEN_QUERY)}${filterIssueStateQuery}`,
     },
     {
-      dataId: 'is:closed',
+      dataId: CLOSED_QUERY,
       icon: <Icon icon="Archive" stroke={COLORS.SECONDORY.PURPLE} />,
       title: `닫힌 이슈 (${closedIssueNum})`,
       link: `${pageQuery}&q=${encodeURIComponent(CLOSED_QUERY)}${filterIssueStateQuery}`,

--- a/src/components/Organisms/IssueTable/IssueItem/index.tsx
+++ b/src/components/Organisms/IssueTable/IssueItem/index.tsx
@@ -13,7 +13,7 @@ import UserImage from '@/components/Atoms/UserImage';
 import { CheckState } from '@/stores/checkBox';
 import calcTimeForToday from '@/utils/calcForTimeToday';
 import { ContentTypes } from '@/api/issue/types';
-import { FilterState } from '@/stores/filter';
+import useFilter from '@/hooks/useFilter';
 
 const IssueItem = (issueInfo: ContentTypes) => {
   const {
@@ -30,7 +30,7 @@ const IssueItem = (issueInfo: ContentTypes) => {
   } = issueInfo;
 
   const checkState = useRecoilValue(CheckState);
-  const setFilterState = useSetRecoilState(FilterState);
+  const { changeNotEngFilter } = useFilter();
 
   const issueLink = `/issues/${id}`;
   const milestoneLink = `/milestone/${id}`;
@@ -47,10 +47,6 @@ const IssueItem = (issueInfo: ContentTypes) => {
 
   const isChecked = !!checkState.child.find((checkboxId) => checkboxId === id);
 
-  const handleLabelClick = (filterdLabelTitle: string) => {
-    setFilterState((prev) => ({ ...prev, label: [filterdLabelTitle] }));
-  };
-
   return (
     <S.Template>
       <CheckBox id={id} type="child" checked={isChecked} />
@@ -66,7 +62,9 @@ const IssueItem = (issueInfo: ContentTypes) => {
           </Link>
           <S.Labels>
             {issueLabels.issueLabels.map((labelProps) => (
-              <Label key={labelProps.title} {...labelProps} onClick={() => handleLabelClick(labelProps.title)} />
+              <Link key={labelProps.title} to={`/issues?page=0&q=label%3A${changeNotEngFilter(labelProps.title)}`}>
+                <Label {...labelProps} />
+              </Link>
             ))}
           </S.Labels>
         </S.IssueTitle>

--- a/src/components/Organisms/IssueTable/TableInfoTabs/index.tsx
+++ b/src/components/Organisms/IssueTable/TableInfoTabs/index.tsx
@@ -19,7 +19,6 @@ import * as S from '@/components/Organisms/IssueTable/index.styles';
 import Dropdown from '@/components/Molecules/Dropdown';
 
 import useFilter, { noneFilterReg } from '@/hooks/useFilter';
-import { FilterState } from '@/stores/filter';
 
 const TableInfoTabs = () => {
   const memberId = useRecoilValue(LoginUserInfoState).id;
@@ -46,32 +45,25 @@ const TableInfoTabs = () => {
     AUTHOR_DROPDOWN_ARGS(memberData || []),
   ];
 
-  const { isExistedFilter, setParsingFilterState, setRemovedFilterState } = useFilter();
-  const filterState = useRecoilValue(FilterState);
+  const { isExistedFilter, parseFilter, searchFilter, changeNotEngFilter } = useFilter();
 
   const handleOnFilterTabsClick = (target: HTMLInputElement) => {
     const key = target.dataset.panel!;
-    const value: string = target.dataset.id!;
-    const filter = value.match(noneFilterReg) ? value : `${key}:${value}`;
+    const dataId = target.dataset.id!;
+    const filter = dataId.match(noneFilterReg) ? dataId : `${key}:${changeNotEngFilter(dataId)}`;
 
-    if (isExistedFilter(filter)) {
-      setRemovedFilterState(filter);
-      return;
-    }
-
-    setParsingFilterState(filter);
+    const parsingFilter = parseFilter(filter);
+    searchFilter(parsingFilter);
   };
 
-  const isFilterTabsChecked = (panelId: string) => {
-    const content = filterState[panelId];
+  const isFilterTabsChecked =
+    (panelId: string) =>
+    (dataId: string): boolean => {
+      const value = changeNotEngFilter(dataId);
+      const filter = `${panelId}:${value}`;
 
-    return (dataId: string): boolean => {
-      if (Array.isArray(content)) {
-        return !!content.find((e) => e === dataId);
-      }
-      return content === dataId;
+      return isExistedFilter(filter);
     };
-  };
 
   const handleOnMemberDropdownClick = (filterKey: string) => {
     const isMemberListData = filterKey === 'assignee' || filterKey === 'author';

--- a/src/components/Organisms/IssueTable/index.tsx
+++ b/src/components/Organisms/IssueTable/index.tsx
@@ -19,6 +19,7 @@ import useFilter, { OPEN_QUERY } from '@/hooks/useFilter';
 import CustomErrorBoundary from '@/components/ErrorBoundary';
 import TableInfoTabs from '@/components/Organisms/IssueTable/TableInfoTabs';
 import ErrorInfoTabs from '@/components/Organisms/IssueTable/TableInfoTabs/Error';
+import { FilterState, PageState } from '@/stores/filter';
 
 const PARENT_CHECKBOX_ID = -1;
 
@@ -29,7 +30,8 @@ const IssueTable = ({ issuesData }: { issuesData: IssuesTypes }) => {
   const setDefaultCheckIds = useSetRecoilState(DefaultCheckIds);
   const checkedBoxNum = checkState.child.length;
 
-  const { page, queries } = useRecoilValue(FilterStatsState);
+  const page = useRecoilValue(PageState);
+  const queries = useRecoilValue(FilterState);
 
   const { setParsingFilterState } = useFilter();
 

--- a/src/components/Organisms/IssueTable/index.tsx
+++ b/src/components/Organisms/IssueTable/index.tsx
@@ -12,9 +12,8 @@ import * as S from '@/components/Organisms/IssueTable/index.styles';
 import Table from '@/components/Molecules/Table';
 
 import { IssuesTypes } from '@/api/issue/types';
-import { FilterStatsState } from '@/stores/filter';
 import { openCloseIssue } from '@/components/Molecules/NavLink/options';
-import useFilter, { OPEN_QUERY } from '@/hooks/useFilter';
+import { OPEN_QUERY } from '@/hooks/useFilter';
 
 import CustomErrorBoundary from '@/components/ErrorBoundary';
 import TableInfoTabs from '@/components/Organisms/IssueTable/TableInfoTabs';
@@ -33,13 +32,6 @@ const IssueTable = ({ issuesData }: { issuesData: IssuesTypes }) => {
   const page = useRecoilValue(PageState);
   const queries = useRecoilValue(FilterState);
 
-  const { setParsingFilterState } = useFilter();
-
-  const handleOnOpenClosedNavClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    const clickedNavDataId = event.currentTarget.dataset.id;
-    setParsingFilterState(clickedNavDataId!);
-  };
-
   useEffect(() => {
     const ids: number[] = issues.content.map((issue) => issue.id);
     setDefaultCheckIds(ids);
@@ -56,7 +48,6 @@ const IssueTable = ({ issuesData }: { issuesData: IssuesTypes }) => {
             ) : (
               <NavLink
                 navData={openCloseIssue(openIssueCount, closedIssueCount, page, queries)}
-                handleOnClick={handleOnOpenClosedNavClick}
                 defaultActive={OPEN_QUERY}
               />
             )}

--- a/src/components/Organisms/IssueTable/index.tsx
+++ b/src/components/Organisms/IssueTable/index.tsx
@@ -14,7 +14,7 @@ import Table from '@/components/Molecules/Table';
 import { IssuesTypes } from '@/api/issue/types';
 import { FilterStatsState } from '@/stores/filter';
 import { openCloseIssue } from '@/components/Molecules/NavLink/options';
-import useFilter from '@/hooks/useFilter';
+import useFilter, { OPEN_QUERY } from '@/hooks/useFilter';
 
 import CustomErrorBoundary from '@/components/ErrorBoundary';
 import TableInfoTabs from '@/components/Organisms/IssueTable/TableInfoTabs';
@@ -55,7 +55,7 @@ const IssueTable = ({ issuesData }: { issuesData: IssuesTypes }) => {
               <NavLink
                 navData={openCloseIssue(openIssueCount, closedIssueCount, page, queries)}
                 handleOnClick={handleOnOpenClosedNavClick}
-                defaultActive="is:open"
+                defaultActive={OPEN_QUERY}
               />
             )}
           </S.IssueStates>

--- a/src/components/Organisms/LabelTable/LabelItem/index.tsx
+++ b/src/components/Organisms/LabelTable/LabelItem/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import * as S from '@/components/Organisms/LabelTable/LabelItem/index.styled';
@@ -11,15 +11,16 @@ import { ModalState } from '@/components/Modal';
 
 import { LabelTypes } from '@/api/issue/types';
 import { TABLE_ITEM_BUTTON_INFO } from '@/components/Atoms/Button/options';
+import useFilter from '@/hooks/useFilter';
 
 type LabelItemTypes = LabelTypes & { setDeleteLabelId: React.Dispatch<React.SetStateAction<number>> };
 
 const LabelItem = ({ setDeleteLabelId, ...labelProps }: LabelItemTypes) => {
   const { id, title, backgroundColorCode, description, textColor } = labelProps;
 
-  const navigate = useNavigate();
   const setIsModal = useSetRecoilState<boolean>(ModalState);
   const [isEditLabel, setIsEditLabel] = useState<boolean>(false);
+  const { changeNotEngFilter } = useFilter();
 
   const handleEditButtonClick = () => {
     setIsEditLabel(true);
@@ -30,20 +31,13 @@ const LabelItem = ({ setDeleteLabelId, ...labelProps }: LabelItemTypes) => {
     setDeleteLabelId(deletedLabelId);
   };
 
-  const handleLabelClick = (filteringLabelTitle: string) => {
-    navigate(`/issues?q=label%3A"${filteringLabelTitle}"`);
-  };
-
   return isEditLabel ? (
     <LabelEditForm type="EDIT" labelProps={labelProps} setIsEditLabel={setIsEditLabel} />
   ) : (
     <S.LabelItem>
-      <Label
-        title={title}
-        backgroundColorCode={backgroundColorCode}
-        textColor={textColor}
-        onClick={() => handleLabelClick(title)}
-      />
+      <Link to={`/issues?page=0&q=label%3A${changeNotEngFilter(title)}`}>
+        <Label title={title} backgroundColorCode={backgroundColorCode} textColor={textColor} />
+      </Link>
       <S.Description>{description}</S.Description>
       <S.EditButton>
         <Button {...TABLE_ITEM_BUTTON_INFO.MODIFY} handleOnClick={handleEditButtonClick} />

--- a/src/components/Organisms/MilestoneTable/MilestoneItem/index.tsx
+++ b/src/components/Organisms/MilestoneTable/MilestoneItem/index.tsx
@@ -13,9 +13,11 @@ import { COLORS } from '@/styles/theme';
 import useFetchMilestone from '@/api/milestone/useFetchMilestone';
 import { ClickMilestoneState } from '@/stores/milestone';
 import { MilestoneTypes } from '@/api/issue/types';
+import useFilter from '@/hooks/useFilter';
 
 const MilestoneItem = (props: MilestoneTypes) => {
   const { patchMilestoneStateMutate } = useFetchMilestone();
+  const { changeNotEngFilter } = useFilter();
 
   const { id, title, description, dueDate, openIssueCount, closedIssueCount, closed } = props;
   const [isOpenModifyEditer, setIsOpenModifyEditer] = useState(false);
@@ -26,7 +28,7 @@ const MilestoneItem = (props: MilestoneTypes) => {
     <>
       <S.MilestoneItem>
         <S.MilestoneItemInfo>
-          <Link to={`/issues?q=milestone%3A"${title}"`} className="MilestoneItem_title">
+          <Link to={`/issues?page=0&q=milestone%3A${changeNotEngFilter(title)}`} className="MilestoneItem_title">
             <Icon icon="Milestone" fill={COLORS.PRIMARY.BLUE} stroke={COLORS.PRIMARY.BLUE} />
             <span>{title}</span>
           </Link>

--- a/src/components/Organisms/MilestoneTable/MilestoneItem/index.tsx
+++ b/src/components/Organisms/MilestoneTable/MilestoneItem/index.tsx
@@ -26,7 +26,7 @@ const MilestoneItem = (props: MilestoneTypes) => {
     <>
       <S.MilestoneItem>
         <S.MilestoneItemInfo>
-          <Link to={`/milestone/${id}`} className="MilestoneItem_title">
+          <Link to={`/issues?q=milestone%3A"${title}"`} className="MilestoneItem_title">
             <Icon icon="Milestone" fill={COLORS.PRIMARY.BLUE} stroke={COLORS.PRIMARY.BLUE} />
             <span>{title}</span>
           </Link>

--- a/src/components/Organisms/Pagination/index.tsx
+++ b/src/components/Organisms/Pagination/index.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 
 import { useRecoilValue } from 'recoil';
-import { FilterStatsState } from '@/stores/filter';
+import { FilterState } from '@/stores/filter';
 
 import * as S from '@/components/Organisms/Pagination/index.styled';
 import Button from '@/components/Atoms/Button';
@@ -9,7 +9,7 @@ import { buttonLogic } from '@/components/Organisms/Pagination/helper';
 
 const Paginiation = ({ totalPages, currentPage }: { totalPages: number; currentPage: number }): JSX.Element => {
   const navigate = useNavigate();
-  const { queries } = useRecoilValue(FilterStatsState);
+  const queries = useRecoilValue(FilterState);
 
   const PaginationButtons = (total: number, current: number) => {
     const isNumber = (x: any): x is number => typeof x === 'number';

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -60,7 +60,24 @@ const useNewFilter = () => {
     return engReg.test(value) ? value : `"${value}"`;
   };
 
-  return { isExistedFilter, parseFilter, searchFilter, changeNotEngFilter };
+  const changeFilterToURL = (filter: string) => {
+    const meReg = /(\w+):@me/g;
+    const queryReg = /(\w+):(\w+)/g;
+    const parsingReg = /\w+:".*?"/g;
+
+    const URL =
+      filter
+        .replace(noneFilterReg, ' $1:""')
+        .replace(meReg, `$1:"${loginUserInfo.nickname}"`)
+        .replace(queryReg, '$1:"$2"')
+        .match(parsingReg)
+        ?.map((e) => encodeURIComponent(e))
+        .join('+') || '';
+
+    return URL;
+  };
+
+  return { isExistedFilter, parseFilter, searchFilter, changeNotEngFilter, changeFilterToURL };
 };
 
 export default useNewFilter;

--- a/src/mocks/handlers/issue.ts
+++ b/src/mocks/handlers/issue.ts
@@ -6,7 +6,7 @@ import { IssuesTypes, CommentsTypes, ContentTypes, IssueHistoryTypes, ReactionRe
 import { userTable } from '@/mocks/handlers/auth';
 import { MILESTONE_LIST, USER_LIST } from '@/components/Molecules/Dropdown/mock';
 import { responseNewIssueData } from '@/mocks/tables/newIssueHelper';
-import { doubleQuotationReg, issueStateReg, OPEN_QUERY } from '@/hooks/useFilter';
+import { OPEN_QUERY, CLOSED_QUERY } from '@/hooks/useFilter';
 import { labelTable } from '@/mocks/handlers/label';
 import {
   assigneesHistory,
@@ -84,6 +84,7 @@ export const issueHandlers = [
 
     const queriesArr = queries?.split('+');
     queriesArr?.forEach((query) => {
+      const doubleQuotationReg = /(^"|"$)/g;
       const [key, value] = decodeURIComponent(query).split(':');
       const decodingValue = value?.replace(doubleQuotationReg, '');
 
@@ -131,6 +132,7 @@ export const issueHandlers = [
     const openStateReg = new RegExp(OPEN_QUERY);
     const stateContent = queries.match(openStateReg) ? openIssueContents : closedIssueContents;
 
+    const issueStateReg = new RegExp(`${OPEN_QUERY}|${CLOSED_QUERY}`);
     const filteredContent = queries.match(issueStateReg)
       ? stateContent
       : [...openIssueContents, ...closedIssueContents];

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -1,72 +1,42 @@
 import { Suspense, useEffect } from 'react';
-import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import useFetchIssue from '@/api/issue/useFetchIssue';
+import { OPEN_QUERY } from '@/hooks/useFilter';
+import { FilterState, PageState } from '@/stores/filter';
+
 import IssuesNavInline from '@/pages/Private/Issues/NavInline';
 import IssueTable from '@/components/Organisms/IssueTable';
-
-import { FilterState, FilterStatsState, initFilterState, PageState } from '@/stores/filter';
-
-import useFilter, { parsingFilterReg } from '@/hooks/useFilter';
 import Paginiation from '@/components/Organisms/Pagination';
 import SkeletonIssueTable from '@/components/Skeleton/IssueTable';
 
 const Issues = () => {
-  const navigate = useNavigate();
-
   const [searchParams] = useSearchParams();
-  const pageParams = Number(searchParams.get('page')) || 0;
-  const queriesParams = searchParams.get('q');
-
-  const filterState = useRecoilValue(FilterState);
-  const resetFilterState = useResetRecoilState(FilterState);
-  const { page, queries } = useRecoilValue(FilterStatsState);
-  const setPageState = useSetRecoilState(PageState);
+  const page = Number(searchParams.get('page')) || 0;
+  const queriesParams = searchParams.get('q') || '';
+  const queries = document.location.search ? queriesParams : OPEN_QUERY;
 
   const { useIssuesData } = useFetchIssue();
-  const { data: issues } = useIssuesData(pageParams, queriesParams);
+  const { data: issues } = useIssuesData(page, queries);
 
-  const { setIssueState, setParsingFilterState } = useFilter();
+  const setFilterState = useSetRecoilState(FilterState);
+  const setPageState = useSetRecoilState(PageState);
 
   const setURLQueriesToFilterState = () => {
-    if (!document.location.search) return;
-    resetFilterState();
-
-    setIssueState(queriesParams);
-
-    const queriesArr = queriesParams?.match(parsingFilterReg);
-    queriesArr?.forEach((query) => {
-      setParsingFilterState(query);
-    });
+    setPageState(page);
+    setFilterState(queries);
   };
 
-  // 쿼리가 변경되면 해당하는 결과로 이동한다.
   useEffect(() => {
-    if (!document.location.search && filterState === initFilterState) return;
-    navigate(`/issues?page=${page}&q=${queries}`);
+    setURLQueriesToFilterState();
   }, [queries]);
-
-  useEffect(() => {
-    setPageState(pageParams);
-
-    // 뒤로가기 시 url의 쿼리와 FilterState를 일치시킨다.
-    if (decodeURIComponent(queries).replaceAll('+', ' ') !== decodeURIComponent(queriesParams!)) {
-      setURLQueriesToFilterState();
-    }
-    // 이전 페이지가 루트인 경우 FilterState를 초기화한다.
-    if (!queriesParams && !pageParams) {
-      resetFilterState();
-    }
-  }, [queriesParams]);
 
   return (
     <>
       <IssuesNavInline />
       <IssueTable issuesData={issues!} />
-      {!!issues!.issues.content.length && (
-        <Paginiation totalPages={issues!.issues.totalPages} currentPage={pageParams} />
-      )}
+      {!!issues!.issues.content.length && <Paginiation totalPages={issues!.issues.totalPages} currentPage={page} />}
     </>
   );
 };

--- a/src/stores/filter.ts
+++ b/src/stores/filter.ts
@@ -1,35 +1,9 @@
 import { atom, selector } from 'recoil';
-import { LoginUserInfoState } from '@/stores/loginUserInfo';
-import { parsingFilterReg } from '@/hooks/useFilter';
+import { OPEN_QUERY } from '@/hooks/useFilter';
 
-export type IssueStateType = 'open' | 'closed' | 'all';
-export type IssueAboutMyselfType = '@me';
-export type NoFilterKeysType = 'assignee' | 'label' | 'milestone';
-
-export interface FilterStateTypes {
-  [key: string]: string | string[];
-  is: IssueStateType;
-  mentions: string | IssueAboutMyselfType;
-  author: string | IssueAboutMyselfType;
-  assignee: string | IssueAboutMyselfType;
-  label: string[];
-  milestone: string;
-  no: NoFilterKeysType[];
-}
-
-export const initFilterState: FilterStateTypes = {
-  is: 'open',
-  author: '',
-  assignee: '',
-  mentions: '',
-  label: [],
-  milestone: '',
-  no: [],
-};
-
-export const FilterState = atom<FilterStateTypes>({
+export const FilterState = atom<string>({
   key: 'FilterState',
-  default: initFilterState,
+  default: OPEN_QUERY,
 });
 
 export const PageState = atom<number>({
@@ -37,54 +11,12 @@ export const PageState = atom<number>({
   default: 0,
 });
 
-const engReg = /^[a-zA-Z]*$/g;
-
 export const FilterStatsState = selector({
   key: 'FilterStatsState',
   get: ({ get }) => {
     const filterState = get(FilterState);
-    const userInfo = get(LoginUserInfoState);
-    const page = get(PageState);
+    const isFiltering = filterState !== OPEN_QUERY;
 
-    const isFiltering = JSON.stringify(filterState) !== JSON.stringify(initFilterState);
-
-    const defineFilterString = (type: 'FILTER_BAR' | 'QUERY') =>
-      Object.keys(filterState)
-        .reduce((acc, key) => {
-          const value = filterState[key];
-
-          if (Array.isArray(value)) {
-            return (
-              acc +
-              value.reduce((accQuery: string, curValue: string) => {
-                if (type === 'FILTER_BAR' && curValue.match(engReg)) return `${accQuery} ${key}:${curValue}`;
-                if (type === 'QUERY' && key === 'no') return `${accQuery} ${curValue}:""`;
-
-                return `${accQuery} ${key}:"${curValue}"`;
-              }, '')
-            );
-          }
-
-          if (typeof value === 'string' && value) {
-            if (key === 'is' && value === 'all') return acc;
-            if (type === 'FILTER_BAR' && (value.match(engReg) || value === '@me')) return `${acc} ${key}:${value}`;
-            if (type === 'QUERY' && value === '@me') return `${acc} ${key}:"${userInfo.nickname}"`;
-
-            return `${acc} ${key}:"${value}"`;
-          }
-
-          return acc;
-        }, '')
-        .trim();
-
-    const filterBarString = defineFilterString('FILTER_BAR');
-    const filterQueryString = defineFilterString('QUERY');
-    const queries =
-      filterQueryString
-        .match(parsingFilterReg)
-        ?.map((e) => encodeURIComponent(e))
-        .join('+') || '';
-
-    return { isFiltering, page, filterBarString, queries };
+    return { isFiltering };
   },
 });


### PR DESCRIPTION
## Description

### 필터링 로직 리팩토링 
 1. 필터탭 클릭 또는 검색어 입력시 url의 쿼리에 필터를 담아 issues 페이지로 이동
 2. issues 페이지 컴포넌트가 렌더링되면서 url를 파싱한다.
 3. 열린 이슈/닫힌 이슈 탭 컴포넌트 및 필터탭 체크박스를 렌더링한다.
 4. API에 맞는 쿼리문으로 변경 후 이슈 데이터를 요청한다.
 
    |  | 필터바 | url |
    |-- | -- | -- |
    | 1. “검색어” | label:Feature | label:”Feature” |
    | 2. no필터 | no:assignee | assignee:”” |
    | 3. 유저(@me) | author:@me | author:”도비” |

### 필터 상태를 객체에서 string 타입으로 변경
  1. 객체 형식에서 필터 조건을 추가하거나 삭제하는 로직대신 string의 가장 마지막에 검색 조건을 붙이거나 해당하는 검색 조건을 빈문자열로 대체한다.

  2. url에 필터값을 담고 있으나 필터값에 따라 렌더링 되어야 하는 컴포넌트들(체크박스, 탭 활성화 등)의 props drilling을 막기 위해 필터 상태를 사용한다. 

## Commits

커밋로그 참조

### 결과
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/92701121/210496400-c7ea9184-7a51-4b28-8812-07eb936f553a.gif)

