### PR TITLE
이슈 관련 페이지와 관련된 반응형 화면 구현

### DIFF
--- a/src/components/Molecules/Comment/index.styled.ts
+++ b/src/components/Molecules/Comment/index.styled.ts
@@ -18,6 +18,7 @@ export const CommentHeader = styled.div`
   }
 
   .timeStamp {
+    white-space: pre;
     color: ${({ theme }) => theme.COLORS.LABEL};
   }
 `;
@@ -43,6 +44,10 @@ export const CommentTab = styled.div`
   ${ReactionPanel} {
     top: 0px;
     right: 25px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    gap: 0px 12px;
   }
 `;
 

--- a/src/components/Molecules/Comment/index.styled.ts
+++ b/src/components/Molecules/Comment/index.styled.ts
@@ -67,7 +67,7 @@ export const CommentContent = styled.div`
 
 export const TextArea = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center', direction: 'column' })};
-  width: 900px;
+  width: 100%;
 `;
 
 export const TextAreaButtonTab = styled.div`

--- a/src/components/Molecules/Dropdown/Indicator/index.styles.ts
+++ b/src/components/Molecules/Dropdown/Indicator/index.styles.ts
@@ -4,7 +4,9 @@ import { DropdownIndicatorTypes } from '@/components/Molecules/Dropdown/types';
 type StyledDropdownIndicatorTypes = Pick<DropdownIndicatorTypes, 'indicatorStyle' | 'isActive'>;
 
 export const Indicator = styled.summary<StyledDropdownIndicatorTypes>`
+.indicator__container {
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center' })};
+}
 
   position: relative;
   width: fit-content;
@@ -59,6 +61,12 @@ export const Indicator = styled.summary<StyledDropdownIndicatorTypes>`
     css`
       background: ${({ theme }) => theme.COLORS.OFF_WHITE};
       border: 1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE};
-      border-right: 1px solid ${({ theme }) => theme.COLORS.LINE};
+      border-right: none;
     `}
+    &::marker,
+    &::-webkit-details-marker {
+      display: none;
+    }
+  }
+}
 `;

--- a/src/components/Molecules/Dropdown/Indicator/index.tsx
+++ b/src/components/Molecules/Dropdown/Indicator/index.tsx
@@ -7,11 +7,13 @@ const DropdownIndicator = ({ ...props }: DropdownIndicatorTypes) => {
   const { indicatorStyle, indicatorLabel, indicatorIcon, isActive } = props;
   return (
     <S.Indicator role="button" indicatorStyle={indicatorStyle} isActive={isActive}>
-      {indicatorLabel && <span>{indicatorLabel}</span>}
-      {indicatorIcon}
-      {indicatorStyle !== 'ICON' && (
-        <Icon icon={indicatorStyle === 'SIDEBAR' ? 'Plus' : 'Caret'} stroke={COLORS.LABEL} />
-      )}
+      <div className="indicator__container">
+        {indicatorLabel && <span>{indicatorLabel}</span>}
+        {indicatorIcon}
+        {indicatorStyle !== 'ICON' && (
+          <Icon icon={indicatorStyle === 'SIDEBAR' ? 'Plus' : 'Caret'} stroke={COLORS.LABEL} />
+        )}
+      </div>
     </S.Indicator>
   );
 };

--- a/src/components/Molecules/SideBar/index.styles.ts
+++ b/src/components/Molecules/SideBar/index.styles.ts
@@ -14,11 +14,33 @@ export const SideBar = styled.div`
     border-bottom: none;
     border-radius: 0 0 16px 16px;
   }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    width: 100%;
+    min-width: 268px;
+  }
 `;
 
 export const SideBarItem = styled.div`
   padding: 34px 32px;
   border-bottom: 1px solid ${({ theme }) => theme.COLORS.LINE};
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    width: 100%;
+
+    details {
+      width: 100%;
+    }
+
+    summary {
+      width: 100%;
+
+      span {
+        display: inline-block;
+        width: 95%;
+      }
+    }
+  }
 `;
 
 export const SideBarContent = styled.ul<{ isEmpty: boolean }>`

--- a/src/components/Molecules/Table/index.styled.ts
+++ b/src/components/Molecules/Table/index.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Table = styled.div`
-  width: 1280px;
+  max-width: 1280px;
   border-radius: 10px;
   color: ${({ theme }) => theme.COLORS.LABEL};
   border: 1px solid ${({ theme }) => theme.COLORS.LINE};

--- a/src/components/Organisms/Header/index.styles.ts
+++ b/src/components/Organisms/Header/index.styles.ts
@@ -21,6 +21,16 @@ export const UserTab = styled.div`
   img {
     display: block;
   }
+
+  /* 갤럭시 폴드에서 헤더가 밀리는 현상때문에 추가*/
+  @media screen and (max-width: 320px) {
+    margin-right: 0px;
+    padding: 2px;
+
+    svg {
+      display: none;
+    }
+  }
 `;
 
 export const LogoutButton = styled.button<{ clickTab: boolean }>`

--- a/src/components/Organisms/IssueHeader/HeaderInline/index.styled.ts
+++ b/src/components/Organisms/IssueHeader/HeaderInline/index.styled.ts
@@ -3,12 +3,16 @@ import styled from 'styled-components';
 export const HeaderInline = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'space-between' })};
   margin-bottom: 16px;
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    ${({ theme }) => theme.MIXIN.FLEX({ direction: 'column-reverse', align: 'flex-start' })};
+  }
 `;
 
 export const Title = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
   ${({ theme }) => theme.FONTSTYLES.DISPLAY_REGULER};
-  width: 940px;
+  max-width: 940px;
   min-height: 48px;
   max-height: max-content;
 
@@ -26,5 +30,9 @@ export const ButtonTab = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'center' })};
   button + button {
     margin-left: 8px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    margin-bottom: 16px;
   }
 `;

--- a/src/components/Organisms/IssueHeader/index.styled.ts
+++ b/src/components/Organisms/IssueHeader/index.styled.ts
@@ -17,18 +17,26 @@ export const HeaderInline = styled.div`
 `;
 
 export const Info = styled.div<{ closed: boolean }>`
-  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
-  gap: 8px;
-
   ${Label} {
+    display: inline-block;
     padding: 8px 16px;
+    margin-bottom: 8px;
     & span {
       color: ${({ theme, closed }) => (!closed ? theme.COLORS.PRIMARY.BLUE : theme.COLORS.SECONDORY.PURPLE)};
     }
   }
+`;
 
-  & > span {
+export const InfoText = styled.div`
+  display: inline-block;
+  margin-left: 8px;
+
+  span {
     ${({ theme }) => theme.FONTSTYLES.TEXT_MEDIUM};
     color: ${({ theme }) => theme.COLORS.BODY};
+  }
+
+  span + span {
+    margin-left: 8px;
   }
 `;

--- a/src/components/Organisms/IssueHeader/index.tsx
+++ b/src/components/Organisms/IssueHeader/index.tsx
@@ -27,9 +27,11 @@ const IssueHeader = ({ id, closed, title, createdAt, author, commentNum }: Issue
           lineColor={closed ? COLORS.SECONDORY.PURPLE : COLORS.PRIMARY.BLUE}
           title={closed ? '닫힌 이슈' : '열린 이슈'}
         />
-        <span>{issueOpenSummary}</span>
-        <span className="splitLine">∙</span>
-        <span>{`코멘트 ${commentNum}개`}</span>
+        <S.InfoText>
+          <span>{issueOpenSummary}</span>
+          <span className="splitLine">∙</span>
+          <span>{`코멘트 ${commentNum}개`}</span>
+        </S.InfoText>
       </S.Info>
     </S.IssueHeader>
   );

--- a/src/components/Organisms/IssueTable/IssueItem/index.styles.ts
+++ b/src/components/Organisms/IssueTable/IssueItem/index.styles.ts
@@ -40,7 +40,7 @@ export const StyledIssue = styled.div`
 
 export const IssueTitle = styled.div`
   display: grid;
-  align-items: center;
+  align-items: baseline;
   justify-content: start;
   grid-template-columns: 20px auto max-content;
   margin-bottom: 8px;

--- a/src/components/Organisms/IssueTable/IssueItem/index.styles.ts
+++ b/src/components/Organisms/IssueTable/IssueItem/index.styles.ts
@@ -1,13 +1,37 @@
 import { Label } from '@/components/Atoms/Label/index.styles';
 import styled from 'styled-components';
 
-export const StyledIssueItem = styled.div`
-  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
-  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
+export const Template = styled.div`
+  display: grid;
+  align-items: center;
+  grid-template-columns: 60px auto 100px;
 
   .checkbox {
     margin-top: -35px;
   }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    grid-template-columns: auto auto;
+
+    .checkbox {
+      display: none;
+    }
+  }
+
+  @media screen and (max-width: 500px) {
+    img {
+      display: none;
+    }
+
+    .summary {
+      margin: 0px;
+    }
+  }
+`;
+
+export const StyledIssueItem = styled.div`
+  ${({ theme }) => theme.MIXIN.FLEX({ align: 'center', justify: 'flex-start' })};
+  background: ${({ theme }) => theme.COLORS.OFF_WHITE};
 `;
 
 export const StyledIssue = styled.div`
@@ -32,6 +56,25 @@ export const IssueTitle = styled.div`
 
   ${Label}+${Label} {
     margin-left: 8px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    width: 100%;
+    grid-template-columns: repeat(2, auto);
+
+    div {
+      grid-column: 1 / 4;
+      overflow: scroll;
+
+      &::-webkit-scrollbar {
+        display: none;
+      }
+    }
+
+    .title {
+      ${({ theme }) => theme.FONTSTYLES.LINK_MEDIUM};
+      margin-bottom: 8px;
+    }
   }
 `;
 
@@ -65,21 +108,25 @@ export const IssueContent = styled.div`
       fill: ${({ theme }) => theme.COLORS.LABEL};
     }
   }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    align-items: flex-start;
+    .summary {
+      margin: 0px;
+    }
+    .milestone {
+      display: none;
+    }
+
+    span:first-child {
+      margin-right: 8px;
+    }
+  }
 `;
 
 export const Assignee = styled.div`
   margin-left: auto;
   img + img {
     margin-left: -10px;
-  }
-`;
-
-export const Template = styled.div`
-  display: grid;
-  align-items: center;
-  grid-template-columns: 60px auto 100px;
-
-  .checkbox {
-    margin-top: -35px;
   }
 `;

--- a/src/components/Organisms/IssueTable/index.styles.ts
+++ b/src/components/Organisms/IssueTable/index.styles.ts
@@ -5,10 +5,30 @@ export const IssueStates = styled.div`
 `;
 
 export const IssueInfoTabs = styled.div`
-  ${({ theme }) => theme.MIXIN.FLEX({ direction: 'row' })};
-  margin-left: auto;
+  ${({ theme }) => theme.MIXIN.FLEX({ direction: 'row', justify: 'flex-end' })};
+
   details + details {
     margin-left: 32px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.TABLET} {
+    details + details {
+      margin-left: 24px;
+    }
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    justify-content: space-around;
+    details + details {
+      margin-left: 4px;
+    }
+
+    details:nth-child(1),
+    details:nth-child(2) {
+      menu {
+        left: 0;
+      }
+    }
   }
 `;
 
@@ -16,6 +36,30 @@ export const IssueTableHeader = styled.div`
   display: grid;
   align-items: center;
   grid-template-columns: 60px 500px auto;
+  width: 100%;
+
+  @media ${({ theme }) => theme.DEVICE.TABLET} {
+    grid-template-columns: 60px auto auto;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    grid-template-columns: auto;
+
+    & > div:nth-child(1),
+    & > div:nth-child(2) {
+      display: none;
+    }
+
+    & > div:nth-child(3) {
+      span {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        display: -webkit-box;
+        -webkit-line-clamp: 1;
+        -webkit-box-orient: vertical;
+      }
+    }
+  }
 `;
 
 export const NoSearchResult = styled.div`

--- a/src/components/Skeleton/IssueTable/index.styles.ts
+++ b/src/components/Skeleton/IssueTable/index.styles.ts
@@ -5,14 +5,30 @@ export const IssueHeader = styled.div`
   width: 100%;
   display: grid;
   align-items: center;
-  grid-template-columns: 5% 65% 30%;
+  grid-template-columns: 5% auto auto;
 
   .skeleton-issue__nav-link {
     ${skeletonRectangle(232, 32)}
   }
 
   .skeleton-issue__filter {
+    justify-self: end;
     ${skeletonRectangle(360, 32)}
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    grid-template-columns: auto;
+    & > div:nth-child(1) {
+      display: none;
+    }
+
+    .skeleton-issue__nav-link {
+      display: none;
+    }
+    .skeleton-issue__filter {
+      justify-self: baseline;
+      width: 100%;
+    }
   }
 `;
 
@@ -22,6 +38,7 @@ export const IssueCheckbox = styled.div`
 `;
 
 export const IssueItem = styled.div`
+  width: 100%;
   display: grid;
   align-items: center;
   grid-template-columns: 5% auto 2%;
@@ -38,6 +55,28 @@ export const IssueItem = styled.div`
   .skeleton-issue__user {
     ${skeletonRectangle(20, 20)}
     border-radius: 50%;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    grid-template-columns: auto;
+    & > div:nth-child(1) {
+      display: none;
+    }
+
+    .skeleton-issue__user {
+      ${skeletonRectangle(20, 20)}
+      display: none;
+    }
+
+    .item__title {
+      width: 100%;
+      max-width: 360px;
+    }
+
+    .item__desc {
+      width: 100%;
+      max-width: 400px;
+    }
   }
 `;
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,8 +12,8 @@ const StyledLayer = styled.div`
   height: 100vh;
 
   & > div {
-    width: 1280px;
-    margin: 0 auto;
+    max-width: 1280px;
+    margin: 12px;
   }
 `;
 

--- a/src/pages/Private/IssueDetail/History/index.styles.ts
+++ b/src/pages/Private/IssueDetail/History/index.styles.ts
@@ -1,17 +1,24 @@
 import styled from 'styled-components';
 
 export const IssueHistory = styled.div`
-  display: flex;
-  align-items: center;
   position: relative;
   gap: 5px;
   margin-left: 92px;
-  padding: 20px 32px;
+  padding: 20px 0px 20px 32px;
   border-left: 1px solid ${({ theme }) => theme.COLORS.LINE};
 
   img {
     width: 28px;
     height: 28px;
+    vertical-align: bottom;
+  }
+
+  span,
+  strong {
+    display: inline-block;
+    cursor: default;
+    vertical-align: text-bottom;
+    margin-left: 5px;
   }
 
   .previous_title,
@@ -26,17 +33,23 @@ export const IssueHistory = styled.div`
   span {
     ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
     color: ${({ theme }) => theme.COLORS.BODY};
-    cursor: default;
   }
 
   strong {
     ${({ theme }) => theme.FONTSTYLES.LINK_SMALL};
-    cursor: default;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    margin-left: 20px;
   }
 `;
 
 export const HistoryLabel = styled.div`
+  display: inline-block;
+  margin-left: 5px;
+
   div {
+    display: inline-block;
     padding: 0 12px;
   }
 

--- a/src/pages/Private/IssueDetail/IssueInfo/index.styles.ts
+++ b/src/pages/Private/IssueDetail/IssueInfo/index.styles.ts
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+import { Divider } from '@/pages/Private/NewIssue/index.styles';
+
+export const IssueInfo = styled.div<{ isNotExistInfo: boolean }>`
+  display: none;
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    display: ${({ isNotExistInfo }) => (isNotExistInfo ? ` none` : `grid`)};
+    grid-template-columns: repeat(2, auto);
+    gap: 12px 20px;
+
+    .milestone__title {
+      ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+    }
+  }
+`;
+
+export const ImagesWrapper = styled.div`
+  display: flex;
+  align-items: center;
+
+  img {
+    width: 26px;
+    height: 26px;
+  }
+
+  img + img {
+    margin-left: 4px;
+  }
+`;
+
+export const LabelWrapper = styled.div`
+  div {
+    display: inline-block;
+    margin: 0px 4px 2px 0px;
+  }
+`;
+
+export const IssueInfoType = styled.span`
+  ${({ theme }) => theme.FONTSTYLES.TEXT_SMALL};
+`;
+
+export const IssueInfoDivider = styled(Divider)`
+  display: none;
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    display: block;
+  }
+`;

--- a/src/pages/Private/IssueDetail/IssueInfo/index.tsx
+++ b/src/pages/Private/IssueDetail/IssueInfo/index.tsx
@@ -1,0 +1,45 @@
+import { ContentTypes } from '@/api/issue/types';
+import Label from '@/components/Atoms/Label';
+import UserImage from '@/components/Atoms/UserImage';
+import * as S from '@/pages/Private/IssueDetail/IssueInfo/index.styles';
+
+const IssueInfo = ({ issue }: { issue: ContentTypes }) => {
+  const { issueAssignees, issueLabels, milestone } = issue;
+  const isNotExistInfo = !issueAssignees.issueAssignees.length && !issueLabels.issueLabels.length && !milestone;
+
+  return (
+    <>
+      <S.IssueInfo isNotExistInfo={isNotExistInfo}>
+        {!!issueAssignees.issueAssignees.length && (
+          <>
+            <S.IssueInfoType>Assignees</S.IssueInfoType>
+            <S.ImagesWrapper>
+              {issueAssignees.issueAssignees.map((assinees) => (
+                <UserImage {...assinees} imgSize="SMALL" key={assinees.id} />
+              ))}
+            </S.ImagesWrapper>
+          </>
+        )}
+        {!!issueLabels.issueLabels.length && (
+          <>
+            <S.IssueInfoType>Labels</S.IssueInfoType>
+            <S.LabelWrapper>
+              {issueLabels.issueLabels.map((label) => (
+                <Label {...label} key={label.id} />
+              ))}
+            </S.LabelWrapper>
+          </>
+        )}
+        {!!milestone && (
+          <>
+            <S.IssueInfoType>Milestone</S.IssueInfoType>
+            <span className="milestone__title">{milestone.title}</span>
+          </>
+        )}
+      </S.IssueInfo>
+      {!isNotExistInfo && <S.IssueInfoDivider />}
+    </>
+  );
+};
+
+export default IssueInfo;

--- a/src/pages/Private/IssueDetail/index.styled.ts
+++ b/src/pages/Private/IssueDetail/index.styled.ts
@@ -5,6 +5,11 @@ import { Table } from '@/components/Molecules/Table/index.styled';
 
 export const IssueContent = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'center' })};
+  width: 100%;
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    flex-direction: column;
+  }
 `;
 
 export const Aside = styled.div`
@@ -12,14 +17,23 @@ export const Aside = styled.div`
     margin: 12px 30px 0px auto;
     color: ${({ theme }) => theme.COLORS.ERROR.RED};
   }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    width: 100%;
+  }
 `;
 
 export const IssueComments = styled.div`
   margin-right: 32px;
+  width: 100%;
 
   & > button {
     margin-top: 16px;
     margin-left: auto;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    margin-bottom: 16px;
   }
 `;
 
@@ -31,11 +45,18 @@ export const Comment = styled.div`
   }
 
   ${Table} {
-    width: 880px;
+    max-width: 880px;
+    width: 100%;
   }
 
   ${Img} {
     margin-right: 16px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    img {
+      display: none;
+    }
   }
 `;
 
@@ -44,10 +65,22 @@ export const NewComment = styled.div`
   margin-top: 40px;
 
   ${TextAreaContainer} {
-    width: 880px;
+    width: 100%;
   }
 
   ${Img} {
     margin-right: 16px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    width: 100%;
+
+    img {
+      display: none;
+    }
+
+    & > div:nth-child(2) {
+      width: 100%;
+    }
   }
 `;

--- a/src/pages/Private/IssueDetail/index.tsx
+++ b/src/pages/Private/IssueDetail/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable array-callback-return */
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { useParams } from 'react-router-dom';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
@@ -15,6 +15,7 @@ import Comment from '@/components/Molecules/Comment';
 import IssueHeader from '@/components/Organisms/IssueHeader';
 import IsssueDetailAside from '@/pages/Private/IssueDetail/Aside';
 import IssueHistory from '@/pages/Private/IssueDetail/History';
+import IssueInfo from './IssueInfo';
 
 const IssueDetail = (): JSX.Element => {
   const { issueId } = useParams();
@@ -70,6 +71,7 @@ const IssueDetail = (): JSX.Element => {
         commentNum={comments.length}
       />
       <S.IssueContent>
+        <IssueInfo issue={issue!} />
         <S.IssueComments>
           {sortTimeLine.map((content, index) => {
             if (isIssueCommentsTypes(content)) {

--- a/src/pages/Private/Issues/NavInline/index.styled.ts
+++ b/src/pages/Private/Issues/NavInline/index.styled.ts
@@ -2,7 +2,27 @@ import styled from 'styled-components';
 
 export const NavInline = styled.div`
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'baseline', justify: 'space-between' })};
-  width: 1280px;
+  max-width: 1280px;
+
+  @media screen and (max-width: 1120px) {
+    ${({ theme }) => theme.MIXIN.FLEX({ direction: 'column', align: 'flex-start' })};
+    margin-bottom: 20px;
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    & > div:nth-child(1) {
+      width: 100%;
+
+      div,
+      form {
+        width: 100%;
+      }
+
+      span {
+        min-width: 32px;
+      }
+    }
+  }
 `;
 
 export const SubNav = styled.div`

--- a/src/pages/Private/NewIssue/index.styles.ts
+++ b/src/pages/Private/NewIssue/index.styles.ts
@@ -1,7 +1,6 @@
 import styled, { css } from 'styled-components';
 
 export const NewIssue = styled.div`
-  width: 1280px;
   h1 {
     ${({ theme }) => theme.FONTSTYLES.DISPLAY_REGULER};
   }
@@ -17,10 +16,20 @@ export const Divider = styled.div`
 export const NewIssueEditer = styled.div`
   width: 100%;
   ${({ theme }) => theme.MIXIN.FLEX({ align: 'flex-start', justify: 'space-between' })};
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    ${({ theme }) => theme.MIXIN.FLEX({ direction: 'column' })};
+
+    img {
+      display: none;
+    }
+  }
 `;
 
 export const NewIssueForm = styled.div<{ isActive: boolean }>`
-  width: 880px;
+  margin: 0 12px;
+  min-width: 268px; /* 갤럭시 폴드 width 280px 에서 마진 12px를 뺀 값 */
+  width: 100%;
 
   form {
     position: relative;
@@ -30,6 +39,10 @@ export const NewIssueForm = styled.div<{ isActive: boolean }>`
       isActive
         ? css`1px solid ${({ theme }) => theme.COLORS.TITLE_ACTIVE}`
         : css`1px solid ${({ theme }) => theme.COLORS.LINE}`};
+  }
+
+  @media ${({ theme }) => theme.DEVICE.MOBILE} {
+    margin: 12px;
   }
 `;
 

--- a/src/styles/reset.ts
+++ b/src/styles/reset.ts
@@ -136,6 +136,11 @@ const resetCSS = css`
     border-collapse: collapse;
     border-spacing: 0;
   }
+
+  input,
+  button {
+    margin: 0;
+  }
 `;
 
 export default resetCSS;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -110,6 +110,18 @@ const MIXIN = {
   `,
 };
 
+const DEVICE_SIZE = {
+  MOBILE: 320,
+  TABLET: 768,
+  DESKTOP: 1024,
+};
+
+const DEVICE = {
+  MOBILE: `screen and (max-width: ${DEVICE_SIZE.TABLET - 1}px)`,
+  TABLET: `screen and (min-width: ${DEVICE_SIZE.TABLET}px) and (max-width: ${DEVICE_SIZE.DESKTOP - 1}px)`,
+  DESKTOP: `screen and (min-width: ${DEVICE_SIZE.DESKTOP}px)`,
+};
+
 const THEME = {
   COLORS,
   FONTSTYLES,
@@ -117,6 +129,7 @@ const THEME = {
   TEXT_INPUT_SIZE,
   TEXTAREA_SIZE,
   MIXIN,
+  DEVICE,
 };
 
 export default THEME;


### PR DESCRIPTION
## Description
- #57 

## Commits
- 디바이스 범위를 관리하기 쉽도록 theme으로 분리했다.
- 대부분의 컴포넌트의 고정 width 수치를 min-width 또는 max-width로 변경하고 width를 100%로 변경했다.

### /issues

https://user-images.githubusercontent.com/85747667/214516796-5458e232-ea45-4754-ac8a-c278d7a16c99.mov

- 모바일 화면의 경우 깃허브의 issues 탭을 참고했다.
    - IssueTable의 헤더의 체크박스와 열린/닫힌 이슈 탭을 보이지 않게 처리했다.
    - 화면 너비가 380px 이하일 경우 필터 드롭다운의 텍스트가 말줄임표로 보이게 처리했다.
    - 화면 너비가 500px 이하일 경우 담당자의 이미지가 보이지 않게 처리했다.

### /issues/new

https://user-images.githubusercontent.com/85747667/214519450-9afc829e-a74f-4c6d-82dd-149cc4e18f9b.mov
- 모바일 화면의 경우 작성자의 프로필 이미지가 보이지 않게 처리했다.
- 모바일 화면의 경우 사이드바가 아래로 가게 처리했다.


### /issues/{ }

https://user-images.githubusercontent.com/85747667/214532854-9520334e-966e-40a3-b03a-8457f1f9ec15.mov


- 모바일 화면의 경우 사이드바가 내려가며 할당된 내용을 볼 수 있도록 IssueInfo 컴포넌트를 추가했다.
- 히스토리 텍스트 배치를 flex에서 inline-block으로 변경하여 화면이 좁아져도 자연스럽게 배치되도록 수정했다.

### safari에서 css 오류 수정
- summary 태그의 marker가 보이는 현상 수정 및 
- summay태그가 flex를 인식하지 못하는 문제 때문에 내부의 요소들을 div로 한 번 더 감싸줌
- input과 button 태그의 default margin 제거
