### PR TITLE
 🐛 이슈 디테일 페이지 로딩 속도 개선

### DIFF
--- a/src/components/Molecules/Comment/index.tsx
+++ b/src/components/Molecules/Comment/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import useFetchReaction from '@/api/issue/useFetchReaction';
+import { ReactionTypes } from '@/api/issue/reaction';
 import useFetchIssue from '@/api/issue/useFetchIssue';
 import { LoginUserInfoState } from '@/stores/loginUserInfo';
 
@@ -31,6 +31,7 @@ interface CommentTypes {
   issueId: number;
   isAuthor: boolean;
   comment: CommentsTypes;
+  reactions: ReactionTypes[];
 }
 
 interface ReactorsTypes {
@@ -71,6 +72,7 @@ const Comment = ({
   isAuthor,
   comment,
   setSelectCommentId,
+  reactions,
 }: CommentTypes & MoleculesCommentType): JSX.Element => {
   const { id: commentId, author, content, createdAt, issueCommentReactionsResponse } = comment;
 
@@ -82,9 +84,6 @@ const Comment = ({
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [isCommentModalOpen, setCommentModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useRecoilState(ModalState);
-
-  const { useReactionData } = useFetchReaction();
-  const { data: reactions } = useReactionData();
 
   const memberId = useRecoilValue(LoginUserInfoState).id;
   const hasReaction = issueCommentReactionsResponse.length > 0;
@@ -153,7 +152,7 @@ const Comment = ({
                   indicatorIcon: <Icon icon="Smile" stroke={COLORS.LABEL} />,
                 }}
                 type="Reaction"
-                panelProps={{ issueId, commentId, memberId, reactions: reactions!, usedEmojis }}
+                panelProps={{ issueId, commentId, memberId, reactions, usedEmojis }}
               />
             </S.CommentTab>
           </S.CommentHeader>
@@ -165,7 +164,7 @@ const Comment = ({
             </ReactMarkdown>
             {hasReaction && (
               <ReactionContainer
-                reactions={reactions!}
+                reactions={reactions}
                 usedEmojis={usedEmojis}
                 issueId={issueId}
                 commentId={commentId}

--- a/src/pages/Private/IssueDetail/index.tsx
+++ b/src/pages/Private/IssueDetail/index.tsx
@@ -15,13 +15,17 @@ import Comment from '@/components/Molecules/Comment';
 import IssueHeader from '@/components/Organisms/IssueHeader';
 import IsssueDetailAside from '@/pages/Private/IssueDetail/Aside';
 import IssueHistory from '@/pages/Private/IssueDetail/History';
-import IssueInfo from './IssueInfo';
+import useFetchReaction from '@/api/issue/useFetchReaction';
+import IssueInfo from '@/pages/Private/IssueDetail/IssueInfo';
 
 const IssueDetail = (): JSX.Element => {
   const { issueId } = useParams();
   const { useIssueData, useAddIssueComment } = useFetchIssue(Number(issueId));
   const { data: issue } = useIssueData(Number(issueId));
   const { mutate: addIssueComment } = useAddIssueComment(Number(issueId));
+
+  const { useReactionData } = useFetchReaction();
+  const { data: reactions } = useReactionData();
 
   const { id, closed, title, createdAt, lastModifiedAt, author, comments, issueHistories } = issue!;
 
@@ -85,6 +89,7 @@ const IssueDetail = (): JSX.Element => {
                     comment={content}
                     setSelectCommentId={setSelectCommentId}
                     isMainComment={index === 0}
+                    reactions={reactions!}
                   />
                 </S.Comment>
               );


### PR DESCRIPTION
## Description
- Comment 컴포넌트에서 중복으로 리액션 데이터를 페치하여 이슈 디테일 페이지에서 로딩 속도가 저하되는 문제가 발생했다. 
- IssueDetail 페이지 컴포넌트에서 리액션 데이터 페치를 한번만 수행하도록 로직을 수정했다.

## Commits

커밋로그 참조
