### PR TITLE
✅ 이슈 상세 페이지 및 레이블 페이지 테스트 오류 수정

### DIFF
--- a/src/components/Molecules/LabelEditForm/constants.tsx
+++ b/src/components/Molecules/LabelEditForm/constants.tsx
@@ -42,7 +42,7 @@ export const LABEL_EDIT_FORM_PROPS: LABEL_EDIT_FORM_PROPS_Types = {
   }),
   LABEL_DESCRIPTION: ({ inputValue, onChange, isTyping }) => ({
     inputMaxLength: MAX_DESCRIPTION_LENGTH,
-    inputPlaceholder: '설명 (선택)',
+    inputPlaceholder: '설명(선택)',
     inputSize: 'SMALL',
     inputType: 'text',
     inputValue,

--- a/src/mocks/handlers/issue.ts
+++ b/src/mocks/handlers/issue.ts
@@ -394,7 +394,7 @@ export const issueHandlers = [
   }),
 
   // 이슈 등록
-  rest.post('api/issues?member', async (req, res, ctx) => {
+  rest.post('api/issues?memberId', async (req, res, ctx) => {
     const requestData = await req.json();
     const userId = req.url.searchParams.get('memberId');
     const { title } = requestData;

--- a/src/pages/Private/Issues/index.tsx
+++ b/src/pages/Private/Issues/index.tsx
@@ -23,14 +23,13 @@ const Issues = () => {
   const setFilterState = useSetRecoilState(FilterState);
   const setPageState = useSetRecoilState(PageState);
 
-  const setURLQueriesToFilterState = () => {
-    setPageState(page);
+  useEffect(() => {
     setFilterState(queries);
-  };
+  }, [queries]);
 
   useEffect(() => {
-    setURLQueriesToFilterState();
-  }, [queries]);
+    setPageState(page);
+  }, [page]);
 
   return (
     <>

--- a/src/pages/Private/Labels/Labels.stories.tsx
+++ b/src/pages/Private/Labels/Labels.stories.tsx
@@ -2,8 +2,10 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import { Route, Routes } from 'react-router-dom';
 import Labels from '@/pages/Private/Labels';
 import Milestones from '@/pages/Private/Milestones';
+import Issues from '@/pages/Private/Issues';
 import { labelHandlers } from '@/mocks/handlers/label';
 import { milestoneHandlers } from '@/mocks/handlers/milestone';
+import { issueHandlers } from '@/mocks/handlers/issue';
 
 export default {
   title: 'pages/Labels',
@@ -13,6 +15,7 @@ export default {
       <Routes>
         <Route path="/labels" element={<Story />} />
         <Route path="/milestones" element={<Milestones />} />
+        <Route path="/issues" element={<Issues />} />
       </Routes>
     ),
   ],
@@ -23,6 +26,6 @@ const Template: ComponentStory<typeof Labels> = () => <Labels />;
 export const Initial = Template.bind({});
 Initial.parameters = {
   msw: {
-    handlers: [...labelHandlers, ...milestoneHandlers],
+    handlers: [...issueHandlers, ...labelHandlers, ...milestoneHandlers],
   },
 };

--- a/src/stores/filter.ts
+++ b/src/stores/filter.ts
@@ -1,5 +1,6 @@
 import { atom, selector } from 'recoil';
-import { OPEN_QUERY } from '@/hooks/useFilter';
+
+const OPEN_QUERY = 'is:open';
 
 export const FilterState = atom<string>({
   key: 'FilterState',

--- a/src/test/IssueDetailPage.test.tsx
+++ b/src/test/IssueDetailPage.test.tsx
@@ -139,7 +139,7 @@ describe('이슈 상세페이지 테스트', () => {
 
     const comment = screen.getByText('코멘트를 수정합니다.');
 
-    const deleteCommentButton = screen.getAllByText('삭제')[1];
+    const deleteCommentButton = screen.getAllByText('삭제')[0];
     await user.click(deleteCommentButton);
 
     await waitFor(() => {

--- a/src/test/IssueDetailPage.test.tsx
+++ b/src/test/IssueDetailPage.test.tsx
@@ -15,6 +15,15 @@ const { Initial } = composeStories(SampleIssueDetail);
 
 let DOMContainer = null;
 
+jest.mock(
+  'react-markdown',
+  () =>
+    ({ children }: any) =>
+      children,
+);
+
+jest.mock('remark-gfm', () => () => {});
+
 beforeAll(() => {
   DOMContainer = document.createElement('div');
   document.body.appendChild(DOMContainer);

--- a/src/test/LabelPage.test.tsx
+++ b/src/test/LabelPage.test.tsx
@@ -26,13 +26,6 @@ afterEach(() => server.resetHandlers());
 
 afterAll(() => server.close());
 
-const mockedNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-  ...(jest.requireActual('react-router-dom') as any),
-  useNavigate: () => mockedNavigate,
-}));
-
 const DEBOUNCE_DELAY = 200;
 
 describe('라벨 페이지 테스트', () => {
@@ -162,8 +155,15 @@ describe('라벨 페이지 테스트', () => {
 
   test('레이블을 클릭하면 이슈페이지로 이동', async () => {
     renderLablePageComponent();
-    const label = screen.getByText(/Docs/i);
-    await user.click(label);
-    expect(mockedNavigate).toBeCalledTimes(1);
+    const label = screen.getByText(/Bugs/i);
+    const labelHref = '/issues?page=0&q=label%3A"Bugs"';
+
+    await act(async () => {
+      await user.click(label);
+      window.history.pushState({}, 'Test-Page', labelHref);
+    });
+
+    const FilterBar = screen.getByPlaceholderText('Search all issues') as HTMLInputElement;
+    expect(FilterBar).toHaveValue('label:Bugs');
   });
 });


### PR DESCRIPTION
## Description
- https://github.com/issue-tracker/issue-tracker-web/issues/63

## Commits

### 1. markdown, remark-gfm 라이브러리 관련 오류
markdown이 완전한 ESM 모듈을 지원하지 않으면서 테스트 코드 실행시 export에 대한 에러가 발생했다. 
markdown에 관련한 테스트코드는 없기 때문에 메소드를 모킹하여 해결했다. 

```jsx
jest.mock('react-markdown', () => ({ children }: any) => <>{children}</>);

jest.mock('remark-gfm', () => () => {});
```

### 2. IssueDetailPage.test.tsx의 '이슈 코멘트 삭제' 테스트 오류
메인코멘트를 제외한 일반 코멘트에서만 삭제기능을 수행하는 기능을 추가하며 생긴 오류다.  
작성자이면서(`isAuthor`) 메인 코멘트 아닌 경우(`!isMainComment`) 삭제버튼이 나타난다. 테스트 하고자하는 `/issues/9` 는 메인코멘트만 존재하는 이슈이다. 테스트 코드에서 새로운 코멘트를 등록했으므로 삭제가능한 코멘트는 한개가 된다. 삭제 버튼을 접근하려면 화면에서 `'삭제'` 라는 텍스트를 가진 모든 요소들 중에 0번째 인덱스에 접근해야 한다. 

```jsx
// 수정전 
const deleteCommentButton = screen.getAllByText('삭제')[1];

// 수정후 
const deleteCommentButton = screen.getAllByText('삭제')[0];
```
### 3. LabelPage.test.tsx의 '레이블을 클릭하면 이슈페이지로 이동' 테스트 오류
필터 로직 리팩토링으로 useNavigate 목함수 호출을 확인하던 것에서 Link to 경로 이동을 확인하는 것으로 라우팅 테스트를 수정했다. 
jsdom의 url이 변경되지 않기 때문에 url로부터 query를 파싱할 수 없으므로 테스트에서 history에 이동 경로를 push한다. 
    
```jsx
const labelHref = '/issues?page=0&q=label%3A"Bugs"';

await act(async () => {
    await user.click(label);
    window.history.pushState({}, 'Test-Page', labelHref);
 });
```
이후 이동한 이슈페이지의 필터바에 해당 레이블을 검색하는 문구가 출력되는지 확인한다. 
```jsx
const FilterBar = screen.getByPlaceholderText('Search all issues') as HTMLInputElement;
expect(FilterBar).toHaveValue('label:Bugs');
```

### 결과

<img width="301" alt="스크린샷 2023-02-07 오후 5 52 45" src="https://user-images.githubusercontent.com/92701121/217443971-a2a6c89e-0ee1-4918-9bb1-b823dca6034e.png">
