### PR TITLE
🐛 NewIssuePage의 SideBar 오류

### DIFF
--- a/src/pages/Private/NewIssue/index.tsx
+++ b/src/pages/Private/NewIssue/index.tsx
@@ -85,7 +85,7 @@ const NewIssue = () => {
       setContentList({ ...contentList, [contentKey]: [...filterContentList] });
       setNewIssueFormState({
         ...newIssueFormState,
-        [`${contentKey}Ids`]: [...newIssueFormState[`${contentKey}Ids`], findDropdownItem!.id],
+        [`${contentKey}Ids`]: filterContentList.map((list) => list.id),
       });
     }
   };


### PR DESCRIPTION
## Description
- https://github.com/issue-tracker/issue-tracker-web/issues/67

담당자, 레이블 드롭다운 아이템 체크시 및 체크 해제시 NewIssueFormState를 갱신하는 로직이 중복되었다.
NewIssueFormState의 (체크 해제한)담당자 또는 레이블의 id에 filterContentList의 id를 업데이트한다.

## Commits
커밋 로그 참조

